### PR TITLE
Mamba CP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "3rdparty/lm-evaluation-harness"]
 	path = 3rdparty/lm-evaluation-harness
 	url = https://github.com/EleutherAI/lm-evaluation-harness/
+[submodule "dtest"]
+	path = dtest
+	url = git@github.com:garrett361/dtest

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,1 @@
+dtest/conftest.py

--- a/mamba_ssm/modules/block.py
+++ b/mamba_ssm/modules/block.py
@@ -2,7 +2,7 @@
 from typing import Optional
 
 import torch
-from torch import nn, Tensor
+from torch import Tensor, nn
 
 from mamba_ssm.ops.triton.layer_norm import RMSNorm, layer_norm_fn
 

--- a/mamba_ssm/modules/mamba2_cp.py
+++ b/mamba_ssm/modules/mamba2_cp.py
@@ -617,13 +617,6 @@ class MHACP(MHA):
             kv = seq_to_zigzag_comms(kv, self.cp_mesh, self.seq_dim)
 
         k, v = kv.unbind(dim=-3)
-        k = torch.repeat_interleave(
-            k, dim=2, repeats=self.num_heads // self.num_heads_kv
-        )
-        v = torch.repeat_interleave(
-            v, dim=2, repeats=self.num_heads // self.num_heads_kv
-        )
-
         context = self.ring_flash_attn_impl(
             q,
             k,

--- a/mamba_ssm/modules/mamba2_cp.py
+++ b/mamba_ssm/modules/mamba2_cp.py
@@ -370,10 +370,10 @@ def conv(xBC, mamba2: Mamba2, conv_state=None, seq_idx=None) -> torch.Tensor:
         conv_state_seq_len = conv_state.shape[1]
         assert conv_state_seq_len == mamba2.d_conv - 1
         conv_state_inputs = torch.cat([conv_state, xBC[:, :conv_state_seq_len]], dim=1)
-        cont_state_out = conv(conv_state_inputs, mamba2, None, seq_idx)[
+        conv_state_out = conv(conv_state_inputs, mamba2, None, seq_idx)[
             :, -conv_state_seq_len:
         ]
-        out[:, :conv_state_seq_len] = cont_state_out
+        out[:, :conv_state_seq_len] = conv_state_out
     return out
 
 

--- a/mamba_ssm/modules/mamba2_cp.py
+++ b/mamba_ssm/modules/mamba2_cp.py
@@ -7,6 +7,7 @@ import torch.nn.functional as F
 from einops import rearrange
 from torch.profiler import record_function
 
+
 from mamba_ssm.modules.mamba2 import Mamba2
 from mamba_ssm.modules.mha import MHA
 from mamba_ssm.ops.triton.ssd_combined_cp import (

--- a/mamba_ssm/modules/mamba2_cp.py
+++ b/mamba_ssm/modules/mamba2_cp.py
@@ -5,6 +5,7 @@ import torch.distributed as dist
 import torch.distributed._functional_collectives as funcol
 import torch.nn.functional as F
 from einops import rearrange
+from torch.profiler import record_function
 
 from mamba_ssm.modules.mamba2 import Mamba2
 from mamba_ssm.modules.mha import MHA
@@ -382,10 +383,11 @@ def conv_cp(
     cp_mesh: dist.device_mesh.DeviceMesh,
     seq_idx=None,
 ) -> torch.Tensor:
-    conv_state_send = xBC[:, -(mamba2.d_conv - 1) :]
-    # TODO: @goon - make the conv_state send/recv async. Can overlap with the first conv.
-    conv_state_recv = causal_passing_comms(conv_state_send, cp_mesh)
-    return conv(xBC, mamba2, conv_state_recv, seq_idx)
+    with record_function("conv_cp"):
+        conv_state_send = xBC[:, -(mamba2.d_conv - 1) :]
+        # TODO: @goon - make the conv_state send/recv async. Can overlap with the first conv.
+        conv_state_recv = causal_passing_comms(conv_state_send, cp_mesh)
+        return conv(xBC, mamba2, conv_state_recv, seq_idx)
 
 
 def in_proj_split(inputs, mamba2: Mamba2):
@@ -502,7 +504,7 @@ class Mamba2CP(Mamba2):
         self,
         *args,
         cp_mesh: dist.device_mesh.DeviceMesh,
-        cp_mamba_impl: Literal["serial", "allgather"] = "zigzag",
+        cp_mamba_impl: Literal["serial", "allgather"] = "allgather",
         **kwargs,
     ) -> None:
         self.cp_mesh = cp_mesh

--- a/mamba_ssm/modules/mamba2_cp.py
+++ b/mamba_ssm/modules/mamba2_cp.py
@@ -1,0 +1,638 @@
+from typing import Callable, Literal, Optional
+
+import torch
+import torch.distributed as dist
+import torch.distributed._functional_collectives as funcol
+import torch.nn.functional as F
+from einops import rearrange
+
+from mamba_ssm.modules.mamba2 import Mamba2
+from mamba_ssm.modules.mha import MHA
+from mamba_ssm.ops.triton.ssd_combined_cp import (
+    mamba_chunk_scan_combined_allgather_cp,
+    mamba_chunk_scan_combined_non_cp,
+    mamba_chunk_scan_combined_serial_cp,
+)
+
+CP_MAMBA_IMPLS = {
+    "serial": mamba_chunk_scan_combined_serial_cp,
+    "allgather": mamba_chunk_scan_combined_allgather_cp,
+}
+
+
+try:
+    from causal_conv1d import causal_conv1d_fn
+except ImportError:
+    causal_conv1d_fn = None, None
+
+
+class CausalPassingFn(torch.autograd.Function):
+    """
+    Causally pass tensors from one rank to the next, with the ordering defined by the mesh.
+    The first rank receives zeros.
+    """
+
+    @staticmethod
+    def forward(
+        ctx, tensor: torch.Tensor, mesh: dist.device_mesh.DeviceMesh
+    ) -> torch.Tensor:
+        if mesh.ndim != 1:
+            raise ValueError("Only supports 1D DeviceMesh instances.")
+        mesh_size = mesh.size()
+        local_rank = mesh.get_local_rank()
+        group = mesh.get_group()
+        send_to: Optional[int] = local_rank + 1
+        if send_to == mesh_size:
+            send_to = None
+        recv_from: Optional[int] = local_rank - 1
+        if recv_from == -1:
+            recv_from = None
+
+        ctx.group = group
+        ctx.recv_from = recv_from
+        ctx.send_to = send_to
+        ops = []
+        tensor = tensor.contiguous()  # Crucial for correctness
+        if send_to is not None:
+            ops.append(
+                dist.P2POp(
+                    dist.isend, tensor, dist.get_global_rank(group, send_to), group
+                )
+            )
+        if recv_from is not None:
+            recv_buffer = torch.empty_like(tensor)
+            ops.append(
+                dist.P2POp(
+                    dist.irecv,
+                    recv_buffer,
+                    dist.get_global_rank(group, recv_from),
+                    group,
+                )
+            )
+        else:
+            recv_buffer = torch.zeros_like(tensor)
+        for op in dist.batch_isend_irecv(ops):
+            op.wait()
+        return recv_buffer
+
+    @staticmethod
+    def backward(ctx, dtensor: torch.Tensor) -> tuple[Optional[torch.Tensor], None]:
+        dtensor = dtensor.contiguous()  # Crucial for correctness
+        ops = []
+        if ctx.send_to is not None:
+            recv_buffer = torch.empty_like(dtensor)
+            ops.append(
+                dist.P2POp(
+                    dist.irecv,
+                    recv_buffer,
+                    dist.get_global_rank(ctx.group, ctx.send_to),
+                    ctx.group,
+                )
+            )
+        else:
+            recv_buffer = None
+        if ctx.recv_from is not None:
+            ops.append(
+                dist.P2POp(
+                    dist.isend,
+                    dtensor,
+                    dist.get_global_rank(ctx.group, ctx.recv_from),
+                    ctx.group,
+                )
+            )
+        for op in dist.batch_isend_irecv(ops):
+            op.wait()
+        return recv_buffer, None
+
+
+causal_passing_comms = CausalPassingFn.apply
+
+
+def _get_seq_to_zigzag_minishard_maps(
+    group_size: int,
+) -> tuple[dict[int, int], dict[int, int]]:
+    minishard_list = list(range(2 * group_size))
+    minishard_list[::2], minishard_list[1::2] = (
+        minishard_list[:group_size],
+        minishard_list[: group_size - 1 : -1],
+    )
+    seq_to_zigzag_map = {seq: zigzag for seq, zigzag in enumerate(minishard_list)}
+    zigzag_to_seq_map = {zigzag: seq for seq, zigzag in seq_to_zigzag_map.items()}
+    return seq_to_zigzag_map, zigzag_to_seq_map
+
+
+class SeqToZigZagFn(torch.autograd.Function):
+    """
+    Convert from sequentially sharded tensors to zig-zag sharded tensors, as in ring-flash-attn.
+    """
+
+    @staticmethod
+    def forward(
+        ctx, tensor: torch.Tensor, mesh: dist.device_mesh.DeviceMesh, seq_dim: int
+    ) -> torch.Tensor:
+        sharded_seq_len = tensor.shape[seq_dim]
+        assert sharded_seq_len % 2 == 0
+        if mesh.ndim != 1:
+            raise ValueError("Only supports 1D DeviceMesh instances.")
+        mesh_size = mesh.size()
+        assert mesh_size % 2 == 0
+        group = mesh.get_group()
+        mesh_rank = mesh.get_local_rank()
+        seq_to_zigzag_map, zigzag_to_seq_map = _get_seq_to_zigzag_minishard_maps(
+            mesh_size
+        )
+
+        minishard_seq_idxs = (2 * mesh_rank, 2 * mesh_rank + 1)
+        send_to_idxs = tuple(zigzag_to_seq_map[s] for s in minishard_seq_idxs)
+        recv_from_idxs = tuple(seq_to_zigzag_map[s] for s in minishard_seq_idxs)
+
+        ctx.group = group
+        ctx.send_to_idxs = send_to_idxs
+        ctx.recv_from_idxs = recv_from_idxs
+        ctx.seq_dim = seq_dim
+
+        mini_shard_0, mini_shard_1 = tensor.tensor_split(2, dim=seq_dim)
+        # contiguous is crucial for correctness
+        send_buffers = (mini_shard_0.contiguous(), mini_shard_1.contiguous())
+        recv_buffers = (torch.empty_like(mini_shard_0), torch.empty_like(mini_shard_1))
+
+        ops = []
+        for send_buf, send_idx in zip(send_buffers, send_to_idxs):
+            # Use send_idx to tag the comms. Convert to rank via rank = idx // 2
+            ops.append(
+                dist.P2POp(
+                    dist.isend,
+                    send_buf,
+                    dist.get_global_rank(group, send_idx // 2),
+                    group,
+                    send_idx,
+                )
+            )
+        for recv_buf, recv_idx, send_idx in zip(
+            recv_buffers, recv_from_idxs, send_to_idxs
+        ):
+            ops.append(
+                dist.P2POp(
+                    dist.irecv,
+                    recv_buf,
+                    dist.get_global_rank(group, recv_idx // 2),
+                    group,
+                    send_idx,
+                )
+            )
+        for op in dist.batch_isend_irecv(ops):
+            op.wait()
+        return torch.cat(recv_buffers, dim=1).contiguous()
+
+    @staticmethod
+    def backward(ctx, dtensor: torch.Tensor) -> tuple[Optional[torch.Tensor], None]:
+        mini_shard_0, mini_shard_1 = dtensor.tensor_split(2, dim=ctx.seq_dim)
+        # contiguous is crucial for correctness
+        send_buffers = (mini_shard_0.contiguous(), mini_shard_1.contiguous())
+        recv_buffers = (torch.empty_like(mini_shard_0), torch.empty_like(mini_shard_1))
+
+        ops = []
+        for send_buf, send_idx in zip(send_buffers, ctx.recv_from_idxs):
+            ops.append(
+                dist.P2POp(
+                    dist.isend,
+                    send_buf,
+                    dist.get_global_rank(ctx.group, send_idx // 2),
+                    ctx.group,
+                    send_idx,
+                )
+            )
+        for recv_buf, recv_idx, send_idx in zip(
+            recv_buffers, ctx.send_to_idxs, ctx.recv_from_idxs
+        ):
+            ops.append(
+                dist.P2POp(
+                    dist.irecv,
+                    recv_buf,
+                    dist.get_global_rank(ctx.group, recv_idx // 2),
+                    ctx.group,
+                    send_idx,
+                )
+            )
+        for op in dist.batch_isend_irecv(ops):
+            op.wait()
+
+        return torch.cat(recv_buffers, dim=1).contiguous(), None, None
+
+
+seq_to_zigzag_comms = SeqToZigZagFn.apply
+
+
+class ZigZagToSeqFn(torch.autograd.Function):
+    """
+    Convert from zig-zag sharded tensors to sequentually sharded tensors, as in ring-flash-attn.
+    """
+
+    @staticmethod
+    def forward(
+        ctx, tensor: torch.Tensor, mesh: dist.device_mesh.DeviceMesh, seq_dim: int
+    ) -> torch.Tensor:
+        sharded_seq_len = tensor.shape[seq_dim]
+        assert sharded_seq_len % 2 == 0
+        if mesh.ndim != 1:
+            raise ValueError("Only supports 1D DeviceMesh instances.")
+        mesh_size = mesh.size()
+        assert mesh_size % 2 == 0
+        group = mesh.get_group()
+        mesh_rank = mesh.get_local_rank()
+        seq_to_zigzag_map, zigzag_to_seq_map = _get_seq_to_zigzag_minishard_maps(
+            mesh_size
+        )
+
+        minishard_seq_idxs = (2 * mesh_rank, 2 * mesh_rank + 1)
+        send_to_idxs = tuple(seq_to_zigzag_map[s] for s in minishard_seq_idxs)
+        recv_from_idxs = tuple(zigzag_to_seq_map[s] for s in minishard_seq_idxs)
+
+        ctx.group = group
+        ctx.send_to_idxs = send_to_idxs
+        ctx.recv_from_idxs = recv_from_idxs
+        ctx.seq_dim = seq_dim
+
+        mini_shard_0, mini_shard_1 = tensor.tensor_split(2, dim=seq_dim)
+        # contiguous is crucial for correctness
+        send_buffers = (mini_shard_0.contiguous(), mini_shard_1.contiguous())
+        recv_buffers = (torch.empty_like(mini_shard_0), torch.empty_like(mini_shard_1))
+
+        ops = []
+        for send_buf, send_idx in zip(send_buffers, send_to_idxs):
+            # Use send_idx to tag the comms. Convert to rank via rank = idx // 2
+            ops.append(
+                dist.P2POp(
+                    dist.isend,
+                    send_buf,
+                    dist.get_global_rank(group, send_idx // 2),
+                    group,
+                    send_idx,
+                )
+            )
+        for recv_buf, recv_idx, send_idx in zip(
+            recv_buffers, recv_from_idxs, send_to_idxs
+        ):
+            ops.append(
+                dist.P2POp(
+                    dist.irecv,
+                    recv_buf,
+                    dist.get_global_rank(group, recv_idx // 2),
+                    group,
+                    send_idx,
+                )
+            )
+        for op in dist.batch_isend_irecv(ops):
+            op.wait()
+        return torch.cat(recv_buffers, dim=1).contiguous()
+
+    @staticmethod
+    def backward(ctx, dtensor: torch.Tensor) -> tuple[Optional[torch.Tensor], None]:
+        mini_shard_0, mini_shard_1 = dtensor.tensor_split(2, dim=ctx.seq_dim)
+        # contiguous is crucial for correctness
+        send_buffers = (mini_shard_0.contiguous(), mini_shard_1.contiguous())
+        recv_buffers = (torch.empty_like(mini_shard_0), torch.empty_like(mini_shard_1))
+
+        ops = []
+        for send_buf, send_idx in zip(send_buffers, ctx.recv_from_idxs):
+            ops.append(
+                dist.P2POp(
+                    dist.isend,
+                    send_buf,
+                    dist.get_global_rank(ctx.group, send_idx // 2),
+                    ctx.group,
+                    send_idx,
+                )
+            )
+        for recv_buf, recv_idx, send_idx in zip(
+            recv_buffers, ctx.send_to_idxs, ctx.recv_from_idxs
+        ):
+            ops.append(
+                dist.P2POp(
+                    dist.irecv,
+                    recv_buf,
+                    dist.get_global_rank(ctx.group, recv_idx // 2),
+                    ctx.group,
+                    send_idx,
+                )
+            )
+        for op in dist.batch_isend_irecv(ops):
+            op.wait()
+
+        return torch.cat(recv_buffers, dim=1).contiguous(), None, None
+
+
+zigzag_to_seq_comms = ZigZagToSeqFn.apply
+
+
+class IdentityFwdAllReduceBwdFn(torch.autograd.Function):
+    """
+    Wrapper for all-gathering grads onto unsharded tensors which are used in rank-sharded
+    operations.
+    """
+
+    @staticmethod
+    def forward(
+        ctx, tensor: torch.Tensor, mesh: dist.device_mesh.DeviceMesh
+    ) -> torch.Tensor:
+        if mesh.ndim != 1:
+            raise ValueError("Only supports 1D DeviceMesh instances.")
+        ctx.mesh = mesh
+        return tensor
+
+    @staticmethod
+    def backward(ctx, dtensor: torch.Tensor) -> tuple[torch.Tensor, None]:
+        dtensor = funcol.all_reduce(dtensor, reduceOp="sum", group=ctx.mesh.get_group())
+        return dtensor, None
+
+
+identity_fwd_all_reduce_bwd = IdentityFwdAllReduceBwdFn.apply
+
+
+# Break down the Mamba2 forward into components
+
+
+def conv(xBC, mamba2: Mamba2, conv_state=None, seq_idx=None) -> torch.Tensor:
+    """
+    Perform causal_conv1d_fn correcting for any previous conv_state, if any.
+    """
+    if seq_idx is not None:
+        raise NotImplementedError
+    out = causal_conv1d_fn(
+        xBC.transpose(1, 2),
+        rearrange(mamba2.conv1d.weight, "d 1 w -> d w"),
+        bias=mamba2.conv1d.bias,
+        activation=mamba2.activation,
+        seq_idx=seq_idx,
+    ).transpose(1, 2)
+    if conv_state is not None:
+        conv_state_seq_len = conv_state.shape[1]
+        assert conv_state_seq_len == mamba2.d_conv - 1
+        conv_state_inputs = torch.cat([conv_state, xBC[:, :conv_state_seq_len]], dim=1)
+        cont_state_out = conv(conv_state_inputs, mamba2, None, seq_idx)[
+            :, -conv_state_seq_len:
+        ]
+        out[:, :conv_state_seq_len] = cont_state_out
+    return out
+
+
+def conv_cp(
+    xBC,
+    mamba2: Mamba2,
+    cp_mesh: dist.device_mesh.DeviceMesh,
+    seq_idx=None,
+) -> torch.Tensor:
+    conv_state_send = xBC[:, -(mamba2.d_conv - 1) :]
+    conv_state_recv = causal_passing_comms(conv_state_send, cp_mesh)
+    return conv(xBC, mamba2, conv_state_recv, seq_idx)
+
+
+def in_proj_split(inputs, mamba2: Mamba2):
+    batch, seqlen, _ = inputs.shape
+    zxbcdt = mamba2.in_proj(inputs)
+    d_mlp = (
+        zxbcdt.shape[-1]
+        - 2 * mamba2.d_ssm
+        - 2 * mamba2.ngroups * mamba2.d_state
+        - mamba2.nheads
+    ) // 2
+    z0, x0, z, xBC, dt = torch.split(
+        zxbcdt,
+        [
+            d_mlp,
+            d_mlp,
+            mamba2.d_ssm,
+            mamba2.d_ssm + 2 * mamba2.ngroups * mamba2.d_state,
+            mamba2.nheads,
+        ],
+        dim=-1,
+    )
+    return z0, x0, z, xBC, dt
+
+
+def scan(
+    chunk_scan_combined_impl: Callable,
+    xBC: torch.Tensor,
+    dt: torch.Tensor,
+    z: torch.Tensor,
+    mamba2: Mamba2,
+    seq_idx=None,
+    cp_mesh: Optional[dist.device_mesh.DeviceMesh] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    x, B, C = torch.split(
+        xBC,
+        [
+            mamba2.d_ssm,
+            mamba2.ngroups * mamba2.d_state,
+            mamba2.ngroups * mamba2.d_state,
+        ],
+        dim=-1,
+    )
+    A = -torch.exp(mamba2.A_log.float())  # (nheads) or (d_inner, d_state)
+    y = chunk_scan_combined_impl(
+        rearrange(x, "b l (h p) -> b l h p", p=mamba2.headdim),
+        dt,
+        A,
+        rearrange(B, "b l (g n) -> b l g n", g=mamba2.ngroups),
+        rearrange(C, "b l (g n) -> b l g n", g=mamba2.ngroups),
+        chunk_size=mamba2.chunk_size,
+        D=rearrange(mamba2.D, "(h p) -> h p", p=mamba2.headdim)
+        if mamba2.D_has_hdim
+        else mamba2.D,
+        z=rearrange(z, "b l (h p) -> b l h p", p=mamba2.headdim)
+        if not mamba2.rmsnorm
+        else None,
+        dt_bias=mamba2.dt_bias,
+        dt_softplus=True,
+        seq_idx=seq_idx,
+        cu_seqlens=None,
+        return_final_states=False,
+        return_varlen_states=False,
+        cp_mesh=cp_mesh,
+    )
+    y = rearrange(y, "b l h p -> b l (h p)")
+    return y
+
+
+class _Mamba2Ref(Mamba2):
+    """
+    Class for testing correctness of the forward rewrite.
+    """
+
+    def forward(self, u, seqlen=None, seq_idx=None, cu_seqlens=None):
+        if seqlen is not None:
+            raise NotImplementedError
+        if seq_idx is not None:
+            raise NotImplementedError
+        if cu_seqlens is not None:
+            raise NotImplementedError
+        z0, x0, z, xBC, dt = in_proj_split(u, self)
+
+        xBC = conv(xBC, self, seq_idx)
+        y = scan(
+            mamba_chunk_scan_combined_non_cp, xBC, dt, z, self, seq_idx, cp_mesh=None
+        )
+
+        if self.rmsnorm:
+            y = self.norm(y, z)
+
+        d_nonssm = (
+            sum(t.shape[-1] for t in (z0, x0, z, xBC, dt))
+            - 2 * self.d_model * self.expand
+            - 2 * self.ngroups * self.d_state
+            - self.nheads
+        ) // 2
+        assert d_nonssm >= 0
+        if d_nonssm > 0:
+            y = torch.cat([F.silu(z0) * x0, y], dim=-1)
+        out = self.out_proj(y)
+        return out
+
+
+class Mamba2CP(Mamba2):
+    """
+    NOTE: @goon - currently we expect an external mechanism to all-reduce the grads which get
+    populated on Mamba2CP instances. This is handled automatically if the model is wrapped in
+    FSDP, but not otherwise. Need to raise a warning or offer some flag for enabling the all-reduce
+    in other cases.
+    """
+
+    def __init__(
+        self,
+        *args,
+        cp_mesh: dist.device_mesh.DeviceMesh,
+        cp_mamba_impl: Literal["serial", "allgather"] = "zigzag",
+        **kwargs,
+    ) -> None:
+        self.cp_mesh = cp_mesh
+        self.cp_mamba_impl = cp_mamba_impl
+        self.cp_impl_fn = CP_MAMBA_IMPLS[self.cp_mamba_impl]
+        super().__init__(*args, **kwargs)
+
+    def forward(
+        self, u, seqlen=None, seq_idx=None, cu_seqlens=None, inference_params=None
+    ):
+        if seqlen is not None:
+            raise NotImplementedError
+        if seq_idx is not None:
+            raise NotImplementedError
+        if cu_seqlens is not None:
+            raise NotImplementedError
+        if inference_params is not None:
+            raise NotImplementedError
+        z0, x0, z, xBC, dt = in_proj_split(u, self)
+
+        xBC = conv_cp(xBC, self, self.cp_mesh, seq_idx)
+        y = scan(
+            self.cp_impl_fn,
+            xBC,
+            dt,
+            z,
+            self,
+            seq_idx,
+            cp_mesh=self.cp_mesh,
+        )
+
+        if self.rmsnorm:
+            y = self.norm(y, z)
+
+        d_nonssm = (
+            sum(t.shape[-1] for t in (z0, x0, z, xBC, dt))
+            - 2 * self.d_model * self.expand
+            - 2 * self.ngroups * self.d_state
+            - self.nheads
+        ) // 2
+        assert d_nonssm >= 0
+        if d_nonssm > 0:
+            y = torch.cat([F.silu(z0) * x0, y], dim=-1)
+        out = self.out_proj(y)
+        return out
+
+
+class MHACP(MHA):
+    """
+    NOTE: @goon - currently we expect an external mechanism to all-reduce the grads which get
+    populated on MHACP instances. This is handled automatically if the model is wrapped in
+    FSDP, but not otherwise. Need to raise a warning or offer some flag for enabling the all-reduce
+    in other cases.
+    """
+
+    def __init__(
+        self,
+        *args,
+        cp_mesh: dist.device_mesh.DeviceMesh,
+        cp_attn_impl: Literal["zigzag", "ring"] = "zigzag",
+        seq_dim: int = 1,
+        **kwargs,
+    ) -> None:
+        if cp_mesh.ndim != 1:
+            raise ValueError("Only supports 1D DeviceMesh instances.")
+        self.cp_mesh = cp_mesh
+        self.cp_attn_impl = cp_attn_impl
+        self.seq_dim = seq_dim
+        if cp_attn_impl == "ring":
+            from ring_flash_attn import ring_flash_attn_func
+
+            self.ring_flash_attn_impl = ring_flash_attn_func
+        elif cp_attn_impl == "zigzag":
+            from ring_flash_attn import zigzag_ring_flash_attn_func
+
+            self.ring_flash_attn_impl = zigzag_ring_flash_attn_func
+        else:
+            raise ValueError(f"Unexpected {cp_attn_impl=}")
+
+        super().__init__(*args, **kwargs)
+        if self.d_conv:
+            raise NotImplementedError
+
+    def forward(self, x, inference_params=None):
+        if inference_params is not None:
+            raise NotImplementedError
+        if self.cp_attn_impl == "zigzag":
+            x = seq_to_zigzag_comms(x, self.cp_mesh, self.seq_dim)
+
+        seqlen_offset = 0
+        rotary_max_seqlen = None
+        qkv = self.in_proj(x)
+
+        if self.mlp_dim > 0:
+            qkv, x_mlp = qkv.split([qkv.shape[-1] - self.mlp_dim, self.mlp_dim], dim=-1)
+            x_mlp_up, x_mlp_gate = x_mlp.chunk(2, dim=-1)
+            x_mlp = x_mlp_up * F.silu(x_mlp_gate)
+
+        q, kv = qkv.split(
+            [self.num_heads * self.head_dim, self.num_heads_kv * 2 * self.head_dim],
+            dim=-1,
+        )
+        q = rearrange(q, "... (h d) -> ... h d", d=self.head_dim)
+        kv = rearrange(kv, "... (two hkv d) -> ... two hkv d", two=2, d=self.head_dim)
+
+        if self.rotary_emb_dim > 0:
+            q, kv = self.rotary_emb(
+                q, kv, seqlen_offset=seqlen_offset, max_seqlen=rotary_max_seqlen
+            )
+
+        k, v = kv.unbind(dim=-3)
+        k = torch.repeat_interleave(
+            k, dim=2, repeats=self.num_heads // self.num_heads_kv
+        )
+        v = torch.repeat_interleave(
+            v, dim=2, repeats=self.num_heads // self.num_heads_kv
+        )
+
+        context = self.ring_flash_attn_impl(
+            q,
+            k,
+            v,
+            causal=self.causal,
+            softmax_scale=self.softmax_scale,
+            group=self.cp_mesh.get_group(),
+        )
+
+        context = rearrange(context, "... h d -> ... (h d)")
+        if self.mlp_dim > 0:
+            context = torch.cat([context, x_mlp], dim=-1)
+        out = self.out_proj(context)
+        if self.cp_attn_impl == "zigzag":
+            out = zigzag_to_seq_comms(out, self.cp_mesh, self.seq_dim)
+        return out

--- a/mamba_ssm/modules/mamba2_cp.py
+++ b/mamba_ssm/modules/mamba2_cp.py
@@ -346,7 +346,7 @@ class IdentityFwdAllReduceBwdFn(torch.autograd.Function):
         return dtensor, None
 
 
-identity_fwd_all_reduce_bwd = IdentityFwdAllReduceBwdFn.apply
+_identity_fwd_all_reduce_bwd = IdentityFwdAllReduceBwdFn.apply
 
 
 # Break down the Mamba2 forward into components
@@ -383,6 +383,7 @@ def conv_cp(
     seq_idx=None,
 ) -> torch.Tensor:
     conv_state_send = xBC[:, -(mamba2.d_conv - 1) :]
+    # TODO: @goon - make the conv_state send/recv async. Can overlap with the first conv.
     conv_state_recv = causal_passing_comms(conv_state_send, cp_mesh)
     return conv(xBC, mamba2, conv_state_recv, seq_idx)
 

--- a/mamba_ssm/ops/triton/ssd_chunk_scan.py
+++ b/mamba_ssm/ops/triton/ssd_chunk_scan.py
@@ -132,7 +132,8 @@ def _chunk_scan_fwd_kernel(
         dA_cs_k = tl.load(dA_cumsum_ptrs, mask=offs_k < chunk_size - k, other=0.0).to(tl.float32)
         # If there's seq_idx, we already set cb[i, j] = 0 for seq_idx[i] != seq_idx[j].
         # So we don't need masking wrt seq_idx here.
-        cb *= tl.exp((dA_cs_m[:, None] - dA_cs_k[None, :]))
+        # cb *= tl.exp((dA_cs_m[:, None] - dA_cs_k[None, :]))
+        cb *= tl.exp(tl.minimum((dA_cs_m[:, None] - dA_cs_k[None, :]), 0.0))
         dt_k = tl.load(dt_ptrs, mask=offs_k < chunk_size - k, other=0.0).to(tl.float32)
         cb *= dt_k
         if IS_CAUSAL:
@@ -679,7 +680,8 @@ def _chunk_scan_bwd_dx_kernel(
         cb = tl.load(cb_ptrs, mask=(offs_m[:, None] < chunk_size) & (offs_k[None, :] < K_MAX - k), other=0.0)
         dout = tl.load(dout_ptrs, mask=(offs_k[:, None] < K_MAX - k) & (offs_n[None, :] < hdim), other=0.0)
         dA_cs_k = tl.load(dA_cumsum_ptrs, mask=offs_k < K_MAX - k, other=0.0).to(tl.float32)
-        cb *= tl.exp(dA_cs_k[None, :] - dA_cs_m[:, None])
+        # cb *= tl.exp(dA_cs_k[None, :] - dA_cs_m[:, None])
+        cb *= tl.exp(tl.minimum((dA_cs_k[None, :] - dA_cs_m[:, None]), 0.0))
         # If we don't have the (k + offs_k[None, :] < K_MAX) mask, for indices outside this range,
         # we might have dA_cs_m = 0.0 and dA_cs_k very negative, and tl.exp will return inf.
         # Multiplying with cb, which is 0.0 outside the range, will make the result NaN.
@@ -816,7 +818,8 @@ def _chunk_scan_bwd_dcb_kernel(
         dcb *= dt_n
         dA_cs_m = tl.load(dA_cumsum_ptr + offs_m * stride_dA_cs_csize, mask=offs_m < chunk_size_limit, other=0.0).to(tl.float32)
         dA_cs_n = tl.load(dA_cumsum_ptr + offs_n * stride_dA_cs_csize, mask=offs_n < chunk_size_limit, other=0.0).to(tl.float32)
-        dcb *= tl.exp(dA_cs_m[:, None] - dA_cs_n[None, :])
+        # dcb *= tl.exp(dA_cs_m[:, None] - dA_cs_n[None, :])
+        dcb *= tl.exp(tl.minimum((dA_cs_m[:, None] - dA_cs_n[None, :]), 0.0))
         if HAS_DDA_CS:
             tl.static_assert(not HAS_SEQ_IDX, "HAS_SEQ_IDX not supported with HAS_DDA_CS yet")
             ddA_cs = dcb * cb
@@ -1008,7 +1011,8 @@ def _chunk_scan_bwd_ddAcs_stable_kernel_old(
     acc *= dt_n
     dA_cs_m = tl.load(dA_cumsum_ptr + offs_m * stride_dA_cs_csize, mask=offs_m < chunk_size, other=0.0).to(tl.float32)
     dA_cs_n = tl.load(dA_cumsum_ptr + offs_n * stride_dA_cs_csize, mask=offs_n < chunk_size, other=0.0).to(tl.float32)
-    acc *= tl.exp(dA_cs_m[:, None] - dA_cs_n[None, :])
+    # acc *= tl.exp(dA_cs_m[:, None] - dA_cs_n[None, :])
+    acc *= tl.exp(tl.minimum((dA_cs_m[:, None] - dA_cs_n[None, :]), 0.0))
     mask = offs_m[:, None] >= offs_n[None, :] + 1
     acc = tl.where(mask, acc, 0.0)
     acc = tl.cumsum(acc, axis=1)
@@ -1134,7 +1138,8 @@ def _chunk_scan_bwd_ddAcs_stable_kernel(
         cb = tl.load(cb_ptrs, mask=(offs_m[:, None] < chunk_size) & (offs_n[None, :] < chunk_size - start_n), other=0.0).to(tl.float32)
         acc *= cb
         dA_cs_n = tl.load(dA_cumsum_ptr + (start_n + offs_n) * stride_dA_cs_csize, mask=offs_n < chunk_size - start_n, other=0.0).to(tl.float32)
-        acc *= tl.exp(dA_cs_m[:, None] - dA_cs_n[None, :])
+        # acc *= tl.exp(dA_cs_m[:, None] - dA_cs_n[None, :])
+        acc *= tl.exp(tl.minimum((dA_cs_m[:, None] - dA_cs_n[None, :]), 0.0))
         mask = offs_m[:, None] >= start_n + offs_n[None, :] + 1
         acc = tl.where(mask, acc, 0.0)
         rowsum_new = rowsum + tl.sum(acc, axis=1)

--- a/mamba_ssm/ops/triton/ssd_chunk_state.py
+++ b/mamba_ssm/ops/triton/ssd_chunk_state.py
@@ -441,7 +441,7 @@ def _chunk_state_bwd_db_kernel(
             scale = tl.exp(tl.minimum((dA_cs_last - dA_cs_m), 0.0))
         else:
             # scale = tl.where(seq_idx_m == seq_idx_last, tl.exp(dA_cs_last - dA_cs_m), 0.0)
-            scale = tl.where(seq_idx_m == seq_idx_last, tl.minimum((dA_cs_last - dA_cs_m), 0.0), 0.0)
+            scale = tl.where(seq_idx_m == seq_idx_last, tl.exp(tl.minimum((dA_cs_last - dA_cs_m), 0.0)), 0.0)
         db *= (scale * dt_m)[:, None]
         if HAS_DDA_CS:
             # This is the gradient wrt (dA_cs_last - dA_cs_m), i.e. the exclusive reverse cumsum

--- a/mamba_ssm/ops/triton/ssd_chunk_state.py
+++ b/mamba_ssm/ops/triton/ssd_chunk_state.py
@@ -141,7 +141,7 @@ def _chunk_cumsum_bwd_kernel(
         dt += dt_bias[:, None]
     if DT_SOFTPLUS:
         dt_presoftplus = dt
-        dt = tl.where(dt <= 20.0, softplus(dt), ddt)
+        dt = tl.where(dt <= 20.0, softplus(dt), dt)
     clamp_mask = (dt < dt_min) | (dt > dt_max)
     # As of Triton 2.2.0, tl.clamp is not available yet
     # dt = tl.clamp(dt, dt_min, dt_max)
@@ -229,9 +229,11 @@ def _chunk_state_fwd_kernel(
             seq_idx_k = tl.load(seq_idx_ptrs, mask=offs_k < chunk_size_limit - k, other=-1)
         dt_k = tl.load(dt_ptrs, mask=offs_k < chunk_size_limit - k, other=0.0).to(tl.float32)
         if not HAS_SEQ_IDX:
-            scale = tl.exp((dA_cs_last - dA_cs_k)) * dt_k
+            # scale = tl.exp((dA_cs_last - dA_cs_k)) * dt_k
+            scale = tl.exp(tl.minimum((dA_cs_last - dA_cs_k), 0.0)) * dt_k
         else:
-            scale = tl.where(seq_idx_k == seq_idx_last, tl.exp((dA_cs_last - dA_cs_k)) * dt_k, 0.0)
+            # scale = tl.where(seq_idx_k == seq_idx_last, tl.exp((dA_cs_last - dA_cs_k)) * dt_k, 0.0)
+            scale = tl.where(seq_idx_k == seq_idx_last, tl.exp(tl.minimum((dA_cs_last - dA_cs_k), 0.0)) * dt_k, 0.0)
         b *= scale[:, None]
         b = b.to(x_ptr.dtype.element_ty)
         acc += tl.dot(x, b)
@@ -332,7 +334,8 @@ def _chunk_state_bwd_dx_kernel(
     dA_cumsum_ptrs = dA_cumsum_ptr + offs_m * stride_dA_cs_csize
     dA_cs_m = tl.load(dA_cumsum_ptrs, mask=offs_m < chunk_size, other=0.0).to(tl.float32)
     dt_m = tl.load(dt_ptrs, mask=offs_m < chunk_size, other=0.0).to(tl.float32)
-    acc *= tl.exp(dA_cs_last - dA_cs_m)[:, None]
+    # acc *= tl.exp(dA_cs_last - dA_cs_m)[:, None]
+    acc *= tl.exp(tl.minimum((dA_cs_last - dA_cs_m), 0.0))[:, None]
 
     x_ptrs = x_ptr + (offs_m[:, None] * stride_x_seqlen + offs_n[None, :] * stride_x_hdim)
     x = tl.load(x_ptrs, mask=(offs_m[:, None] < chunk_size_limit) & (offs_n[None, :] < hdim), other=0.0).to(tl.float32)
@@ -434,9 +437,11 @@ def _chunk_state_bwd_db_kernel(
         dA_cs_m = tl.load(dA_cumsum_ptrs, mask=offs_m < chunk_size, other=0.0).to(tl.float32)
         dt_m = tl.load(dt_ptrs, mask=offs_m < chunk_size, other=0.0).to(tl.float32)
         if not HAS_SEQ_IDX:
-            scale = tl.exp(dA_cs_last - dA_cs_m)
+            # scale = tl.exp(dA_cs_last - dA_cs_m)
+            scale = tl.exp(tl.minimum((dA_cs_last - dA_cs_m), 0.0))
         else:
-            scale = tl.where(seq_idx_m == seq_idx_last, tl.exp(dA_cs_last - dA_cs_m), 0.0)
+            # scale = tl.where(seq_idx_m == seq_idx_last, tl.exp(dA_cs_last - dA_cs_m), 0.0)
+            scale = tl.where(seq_idx_m == seq_idx_last, tl.minimum((dA_cs_last - dA_cs_m), 0.0), 0.0)
         db *= (scale * dt_m)[:, None]
         if HAS_DDA_CS:
             # This is the gradient wrt (dA_cs_last - dA_cs_m), i.e. the exclusive reverse cumsum
@@ -549,11 +554,13 @@ def _chunk_state_bwd_ddAcs_stable_kernel(
     dA_cs_m = tl.load(dA_cumsum_ptr + offs_m * stride_dA_cs_csize, mask=offs_m < chunk_size, other=0.0).to(tl.float32)
     dA_cs_last = tl.load(dA_cumsum_ptr + (chunk_size - 1) * stride_dA_cs_csize).to(tl.float32)
     if not HAS_SEQ_IDX:
-        scale = tl.exp(dA_cs_last - dA_cs_m)
+        # scale = tl.exp(dA_cs_last - dA_cs_m)
+        scale = tl.exp(tl.minimum((dA_cs_last - dA_cs_m), 0.0))
     else:
         seq_idx_m = tl.load(seq_idx_ptr + offs_m * stride_seq_idx_seqlen, mask=offs_m < chunk_size_limit, other=-1)
         seq_idx_last = tl.load(seq_idx_ptr + (chunk_size_limit - 1) * stride_seq_idx_seqlen)
-        scale = tl.where(seq_idx_m == seq_idx_last, tl.exp(dA_cs_last - dA_cs_m), 0.0)
+        # scale = tl.where(seq_idx_m == seq_idx_last, tl.exp(dA_cs_last - dA_cs_m), 0.0)
+        scale = tl.where(seq_idx_m == seq_idx_last, tl.exp(tl.minimum((dA_cs_last - dA_cs_m), 0.0)), 0.0)
     acc *= scale[:, None]
 
     x_ptrs = x_ptr + (offs_m[:, None] * stride_x_seqlen + offs_n[None, :] * stride_x_hdim)
@@ -634,8 +641,10 @@ def _chunk_state_varlen_kernel(
         b = tl.load(b_ptrs, mask=(offs_k[:, None] < chunk_size_limit - k) & (offs_n[None, :] < dstate) & (offs_k[:, None] >= start_idx_cur - k), other=0.0).to(tl.float32)
         dA_cs_k = tl.load(dA_cumsum_ptrs, mask=offs_k < chunk_size_limit - k, other=0.0).to(tl.float32)
         dt_k = tl.load(dt_ptrs, mask=offs_k < chunk_size_limit - k, other=0.0).to(tl.float32)
+        # scale = tl.where((offs_k >= start_idx_cur - k) & (offs_k < chunk_size_limit - k),
+        #                  tl.exp((dA_cs_last - dA_cs_k)) * dt_k, 0.0)
         scale = tl.where((offs_k >= start_idx_cur - k) & (offs_k < chunk_size_limit - k),
-                         tl.exp((dA_cs_last - dA_cs_k)) * dt_k, 0.0)
+                         tl.exp(tl.minimum((dA_cs_last - dA_cs_k), 0.0)) * dt_k, 0.0)
         b *= scale[:, None]
         b = b.to(x_ptr.dtype.element_ty)
         acc += tl.dot(x, b)

--- a/mamba_ssm/ops/triton/ssd_combined_cp.py
+++ b/mamba_ssm/ops/triton/ssd_combined_cp.py
@@ -1,0 +1,1033 @@
+"""
+Utilities for creating context-parallel autograd functions from the triton kernel building blocks.
+
+Every kernel is embarassingly parallel in the sequence dimension, except for
+`_state_passing_{fwd,bwd}`. The `_mamba_chunk_scan_combined_{fwd,bwd}_template` functions below
+mirror their `_mamba_chunk_scan_combined_{fwd,bwd}` counterparts, but take a `_StatePassingImpl`
+implementation which defines the replacements for the original `_state_passing_{fwd,bwd}` kernels.
+
+After defining the `_StatePassingImpl.{fwd,bwd}` methods of an implementation, the
+`_StatePassingImpl.get_chunk_scan_autograd_fn` class method generates the corresponding
+`autograd.Function` using the templated functions above.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Optional, Type
+
+import torch
+import torch.distributed as dist
+import triton
+from einops import rearrange
+from packaging import version
+
+from mamba_ssm.ops.triton.ssd_combined import (
+    _bmm_chunk_bwd,
+    _bmm_chunk_fwd,
+    _chunk_cumsum_fwd,
+    _chunk_scan_bwd_dC,
+    _chunk_scan_bwd_dcb,
+    _chunk_scan_bwd_dstates,
+    _chunk_scan_chunk_state_bwd_dx,
+    _chunk_scan_fwd,
+    _chunk_state_bwd_db,
+    _chunk_state_fwd,
+    _state_passing_bwd,
+    _state_passing_fwd,
+    chunk_state_varlen,
+    _chunk_cumsum_bwd,
+    _chunk_scan_bwd_dz,
+    _chunk_scan_bwd_ddAcs_stable,
+)
+
+TRITON_22 = version.parse(triton.__version__) >= version.parse("2.2.0")
+
+
+class _StatePassingImpl(ABC):
+    @staticmethod
+    @abstractmethod
+    def fwd(
+        chunk_size,
+        states,  # (batch, nchunks, nheads, headdim, d_state)
+        dA_chunk_cumsum,  # (batch, nheads, nchunks)
+        initial_states=None,  # Optional[(batch, nheads, headdim, d_state)]
+        seq_idx=None,
+        out_dtype=None,
+        cp_mesh: Optional[dist.device_mesh.DeviceMesh] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, Any]:
+        """
+        Returns a tuple of (out_states, final_states, bwd_args), where bwd_args is anything that
+        _StatePassingImpl.bwd might require for its backwards pass.
+
+        Shapes:
+        - out_states: (batch, nchunks, nheads, headdim, d_state)
+        - final_states: (batch, nheads, headdim, d_state)
+        """
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def bwd(
+        chunk_size: int,
+        states: torch.Tensor,  # (batch, nchunks, nheads, headdim, d_state)
+        dA_chunk_cumsum: torch.Tensor,  # (batch, nheads, nchunks)
+        dstates: torch.Tensor,  # (batch, nchunks, nheads, headdim, d_state)
+        dstates_dtype: torch.dtype,
+        states_dtype: torch.dtype,
+        initial_states: Optional[
+            torch.Tensor
+        ] = None,  # Optional[(batch, nheads, headdim, d_state)]
+        dfinal_states: Optional[
+            torch.Tensor
+        ] = None,  # Optional[(batch, nheads, headdim, d_state)]
+        seq_idx: Optional[torch.Tensor] = None,
+        cp_mesh: Optional[dist.device_mesh.DeviceMesh] = None,
+        bwd_args: Optional[Any] = None,
+    ) -> tuple[
+        torch.Tensor, torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]
+    ]:
+        """
+        Returns a tuple of (dstates, ddA_chunk_cumsum, dinitial_states, states). bwd_args is
+        whatever may have been passed along by _StatePassingImpl.fwd.
+        Shapes:
+        - dstates_out: (batch, nchunks, nheads, headdim, d_state)
+        - ddA_chunk_cumsum: (batch, nheads, nchunks, n_blocks),  n_blocks set by triton config
+        - dinitial_states: Optional[(batch, nchunks, nheads, headdim, d_state)]
+        - states:  Optional[(batch, nchunks, nheads, headdim, d_state)]
+        """
+        ...
+
+    @classmethod
+    def get_chunk_scan_autograd_fn(cls):
+        class _Fn(torch.autograd.Function):
+            @staticmethod
+            def forward(
+                ctx,
+                x,
+                dt,
+                A,
+                B,
+                C,
+                chunk_size,
+                D=None,
+                z=None,
+                dt_bias=None,
+                initial_states=None,
+                seq_idx=None,
+                cu_seqlens=None,
+                dt_softplus=False,
+                dt_limit=(0.0, float("inf")),
+                return_final_states=False,
+                return_varlen_states=False,
+                cp_mesh: Optional[dist.device_mesh.DeviceMesh] = None,
+            ):
+                ctx.dt_dtype = dt.dtype
+                if not return_varlen_states:
+                    cu_seqlens = None
+                else:
+                    assert cu_seqlens is not None, (
+                        "cu_seqlens must be provided if return_varlen_states is True"
+                    )
+                out, out_x, _, _, _, final_states, *rest = (
+                    _mamba_chunk_scan_combined_fwd_template(
+                        cls,
+                        x,
+                        dt,
+                        A,
+                        B,
+                        C,
+                        chunk_size,
+                        D=D,
+                        z=z,
+                        dt_bias=dt_bias,
+                        initial_states=initial_states,
+                        seq_idx=seq_idx,
+                        cu_seqlens=cu_seqlens,
+                        dt_softplus=dt_softplus,
+                        dt_limit=dt_limit,
+                        cp_mesh=cp_mesh,
+                    )
+                )
+                ctx.save_for_backward(
+                    out if z is None else out_x,
+                    x,
+                    dt,
+                    A,
+                    B,
+                    C,
+                    D,
+                    z,
+                    dt_bias,
+                    initial_states,
+                    seq_idx,
+                )
+                ctx.dt_softplus = dt_softplus
+                ctx.chunk_size = chunk_size
+                ctx.dt_limit = dt_limit
+                ctx.return_final_states = return_final_states
+                ctx.return_varlen_states = return_varlen_states
+                ctx.cp_mesh = cp_mesh
+                if not return_varlen_states:
+                    return out if not return_final_states else (out, final_states)
+                else:
+                    varlen_states = rest[0]
+                    return (
+                        (out, varlen_states)
+                        if not return_final_states
+                        else (out, final_states, varlen_states)
+                    )
+
+            @staticmethod
+            def backward(ctx, dout, *args):
+                (
+                    out,
+                    x,
+                    dt,
+                    A,
+                    B,
+                    C,
+                    D,
+                    z,
+                    dt_bias,
+                    initial_states,
+                    seq_idx,
+                ) = ctx.saved_tensors
+                assert not ctx.return_varlen_states, (
+                    "return_varlen_states is not supported in backward"
+                )
+                dfinal_states = args[0] if ctx.return_final_states else None
+                dx, ddt, dA, dB, dC, dD, dz, ddt_bias, dinitial_states = (
+                    _mamba_chunk_scan_combined_bwd_template(
+                        cls,
+                        dout,
+                        x,
+                        dt,
+                        A,
+                        B,
+                        C,
+                        out,
+                        ctx.chunk_size,
+                        D=D,
+                        z=z,
+                        dt_bias=dt_bias,
+                        initial_states=initial_states,
+                        dfinal_states=dfinal_states,
+                        seq_idx=seq_idx,
+                        dt_softplus=ctx.dt_softplus,
+                        dt_limit=ctx.dt_limit,
+                        cp_mesh=ctx.cp_mesh,
+                    )
+                )
+                return (
+                    dx,
+                    ddt,
+                    dA,
+                    dB,
+                    dC,
+                    None,
+                    dD,
+                    dz,
+                    ddt_bias,
+                    dinitial_states,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+
+        _Fn.__name__ = f"{cls.__name__}Fn"
+
+        def fn(
+            x,
+            dt,
+            A,
+            B,
+            C,
+            chunk_size,
+            D=None,
+            z=None,
+            dt_bias=None,
+            initial_states=None,
+            seq_idx=None,
+            cu_seqlens=None,
+            dt_softplus=False,
+            dt_limit=(0.0, float("inf")),
+            return_final_states=False,
+            return_varlen_states=False,
+            cp_mesh: Optional[dist.device_mesh.DeviceMesh] = None,
+        ):
+            """
+            Argument:
+                x: (batch, seqlen, nheads, headdim)
+                dt: (batch, seqlen, nheads)
+                A: (nheads)
+                B: (batch, seqlen, ngroups, d_state)
+                C: (batch, seqlen, ngroups, d_state)
+                chunk_size: int
+                D: (nheads, headdim) or (nheads,)
+                z: (batch, seqlen, nheads, headdim)
+                dt_bias: (nheads,)
+                initial_states: (batch, nheads, headdim, d_state)
+                seq_idx: (batch, seqlen)
+                cu_seqlens: (num_sequences + 1) or None, only used if return_varlen_states is True
+                dt_softplus: Whether to apply softplus to dt
+                cp_mesh: Optional[DeviceMesh]
+            Return:
+                out: (batch, seqlen, nheads, headdim)
+            """
+            return _Fn.apply(
+                x,
+                dt,
+                A,
+                B,
+                C,
+                chunk_size,
+                D,
+                z,
+                dt_bias,
+                initial_states,
+                seq_idx,
+                cu_seqlens,
+                dt_softplus,
+                dt_limit,
+                return_final_states,
+                return_varlen_states,
+                cp_mesh,
+            )
+
+        return fn
+
+
+# Templates for fwd and bwd passes constructed like _mamba_chunk_scan_combined_{fwd,bwd}, but
+# with customizable state passing impls.
+
+
+def _mamba_chunk_scan_combined_fwd_template(
+    state_passing_impl: Type[_StatePassingImpl],
+    x,
+    dt,
+    A,
+    B,
+    C,
+    chunk_size,
+    D=None,
+    z=None,
+    dt_bias=None,
+    initial_states=None,
+    seq_idx=None,
+    cu_seqlens=None,
+    dt_softplus=False,
+    dt_limit=(0.0, float("inf")),
+    cp_mesh: Optional[dist.device_mesh.DeviceMesh] = None,
+):
+    batch, seqlen, nheads, headdim = x.shape
+    _, _, ngroups, dstate = B.shape
+    assert nheads % ngroups == 0
+    assert B.shape == (batch, seqlen, ngroups, dstate)
+    assert x.shape == (batch, seqlen, nheads, headdim)
+    assert dt.shape == (batch, seqlen, nheads)
+    assert A.shape == (nheads,)
+    assert C.shape == B.shape
+    if z is not None:
+        assert z.shape == x.shape
+    if D is not None:
+        assert D.shape == (nheads, headdim) or D.shape == (nheads,)
+    if seq_idx is not None:
+        assert seq_idx.shape == (batch, seqlen)
+    if B.stride(-1) != 1:
+        B = B.contiguous()
+    if C.stride(-1) != 1:
+        C = C.contiguous()
+    if (
+        x.stride(-1) != 1 and x.stride(1) != 1
+    ):  # Either M or K dimension should be contiguous
+        x = x.contiguous()
+    if (
+        z is not None and z.stride(-1) != 1 and z.stride(1) != 1
+    ):  # Either M or K dimension should be contiguous
+        z = z.contiguous()
+    if D is not None and D.stride(-1) != 1:
+        D = D.contiguous()
+    if initial_states is not None:
+        assert initial_states.shape == (batch, nheads, headdim, dstate)
+    dA_cumsum, dt = _chunk_cumsum_fwd(
+        dt, A, chunk_size, dt_bias=dt_bias, dt_softplus=dt_softplus, dt_limit=dt_limit
+    )
+    states = _chunk_state_fwd(B, x, dt, dA_cumsum, seq_idx=seq_idx, states_in_fp32=True)
+
+    states, final_states, _ = state_passing_impl.fwd(
+        chunk_size=chunk_size,
+        states=states,
+        dA_chunk_cumsum=dA_cumsum[:, :, :, -1],
+        initial_states=initial_states,
+        seq_idx=seq_idx,
+        out_dtype=C.dtype,
+        cp_mesh=cp_mesh,
+    )
+
+    CB = _bmm_chunk_fwd(C, B, chunk_size, seq_idx=seq_idx, output_dtype=torch.float32)
+    out, out_x = _chunk_scan_fwd(
+        CB, x, dt, dA_cumsum, C, states, D=D, z=z, seq_idx=seq_idx
+    )
+    if cu_seqlens is None:
+        return out, out_x, dt, dA_cumsum, states, final_states
+    else:
+        assert batch == 1, (
+            "passing cu_seqlens to get the varlen states is only supported if batch dimension is 1"
+        )
+        varlen_states = chunk_state_varlen(
+            B.squeeze(0),
+            x.squeeze(0),
+            dt.squeeze(0),
+            dA_cumsum.squeeze(0),
+            cu_seqlens,
+            states.squeeze(0),
+        )
+        return out, out_x, dt, dA_cumsum, states, final_states, varlen_states
+
+
+def _mamba_chunk_scan_combined_bwd_template(
+    state_passing_impl: Type[_StatePassingImpl],
+    dout,
+    x,
+    dt,
+    A,
+    B,
+    C,
+    out,
+    chunk_size,
+    D=None,
+    z=None,
+    dt_bias=None,
+    initial_states=None,
+    dfinal_states=None,
+    seq_idx=None,
+    dt_softplus=False,
+    dt_limit=(0.0, float("inf")),
+    dx=None,
+    ddt=None,
+    dB=None,
+    dC=None,
+    dz=None,
+    recompute_output=False,
+    cp_mesh: Optional[dist.device_mesh.DeviceMesh] = None,
+):
+    if dout.stride(-1) != 1:
+        dout = dout.contiguous()
+    batch, seqlen, nheads, headdim = x.shape
+    _, _, ngroups, dstate = B.shape
+    assert dout.shape == (batch, seqlen, nheads, headdim)
+    assert dt.shape == (batch, seqlen, nheads)
+    assert A.shape == (nheads,)
+    assert nheads % ngroups == 0
+    assert B.shape == (batch, seqlen, ngroups, dstate)
+    assert C.shape == B.shape
+    assert out.shape == x.shape
+    if initial_states is not None:
+        assert initial_states.shape == (batch, nheads, headdim, dstate)
+    if seq_idx is not None:
+        assert seq_idx.shape == (batch, seqlen)
+    if dx is not None:
+        assert dx.shape == x.shape
+    if dB is not None:
+        assert dB.shape == B.shape
+        dB_given = dB
+    else:
+        dB_given = torch.empty_like(B)
+    if dC is not None:
+        assert dC.shape == C.shape
+        dC_given = dC
+    else:
+        dC_given = torch.empty_like(C)
+    if dz is not None:
+        assert z is not None
+        assert dz.shape == z.shape
+    if ddt is not None:
+        assert ddt.shape == dt.shape
+        ddt_given = ddt
+    else:
+        ddt_given = torch.empty_like(dt)
+    # TD: For some reason Triton (2.1.0 and 2.2.0) errors with
+    # "[CUDA]: invalid device context" (e.g. during varlne test), and cloning makes it work. Idk why.
+    dt_in = dt.clone()
+    dA_cumsum, dt = _chunk_cumsum_fwd(
+        dt_in,
+        A,
+        chunk_size,
+        dt_bias=dt_bias,
+        dt_softplus=dt_softplus,
+        dt_limit=dt_limit,
+    )
+    CB = _bmm_chunk_fwd(C, B, chunk_size, seq_idx=seq_idx, output_dtype=torch.float32)
+    states = _chunk_state_fwd(B, x, dt, dA_cumsum, seq_idx=seq_idx, states_in_fp32=True)
+
+    states, _, bwd_args = state_passing_impl.fwd(
+        chunk_size=chunk_size,
+        states=states,
+        dA_chunk_cumsum=dA_cumsum[:, :, :, -1],
+        initial_states=initial_states,
+        seq_idx=seq_idx,
+        out_dtype=None,
+        cp_mesh=cp_mesh,
+    )
+
+    if z is not None:
+        dz, dout, dD, *rest = _chunk_scan_bwd_dz(
+            x,
+            z,
+            out,
+            dout,
+            chunk_size=chunk_size,
+            has_ddAcs=False,
+            D=D,
+            dz=dz,
+            recompute_output=recompute_output,
+        )
+        outz = rest[0] if recompute_output else out
+    else:
+        dz = None
+        outz = out
+    dstates = _chunk_scan_bwd_dstates(
+        C, dA_cumsum, dout, seq_idx=seq_idx, dtype=states.dtype
+    )
+
+    dstates, ddA_chunk_cumsum, dinitial_states, states = state_passing_impl.bwd(
+        chunk_size=chunk_size,
+        states=states,
+        dA_chunk_cumsum=dA_cumsum[:, :, :, -1],
+        dstates=dstates,
+        dstates_dtype=x.dtype,
+        states_dtype=x.dtype,
+        initial_states=initial_states,
+        dfinal_states=dfinal_states,
+        seq_idx=seq_idx,
+        cp_mesh=cp_mesh,
+        bwd_args=bwd_args,
+    )
+
+    dx, ddt, dD_from_x = _chunk_scan_chunk_state_bwd_dx(
+        x, dt, dA_cumsum, B, CB, dout, dstates, D=D, seq_idx=seq_idx, dx=dx
+    )
+    dB, ddA_next = _chunk_state_bwd_db(
+        x, dt, dA_cumsum, dstates, seq_idx=seq_idx, B=B, ngroups=ngroups
+    )
+    dC, ddA_cumsum_prev = _chunk_scan_bwd_dC(
+        states.to(x.dtype), dA_cumsum, dout, seq_idx=seq_idx, C=C, ngroups=ngroups
+    )
+    dCB = _chunk_scan_bwd_dcb(x, dt, dA_cumsum, dout, seq_idx=seq_idx, ngroups=ngroups)
+    dCB = dCB.to(CB.dtype)
+    _bmm_chunk_bwd(C, dCB, residual=dB, out=dB_given)
+    _bmm_chunk_bwd(B, rearrange(dCB, "... l s -> ... s l"), residual=dC, out=dC_given)
+    # If we have z, then dout_x is recomputed in fp32 so dD = (dout_x * x).sum() is more accurate
+    # than dD_from_x = (dout_x * x).sum() where dout_x is in fp16/bf16
+    if z is None:
+        dD = dD_from_x
+    ddA_cumsum_prev[..., -1] += ddA_chunk_cumsum
+    ddA_prev = ddA_cumsum_prev.flip([-1]).cumsum(dim=-1).flip([-1])
+    ddA = _chunk_scan_bwd_ddAcs_stable(x, dt, dA_cumsum, dout, CB)
+    ddA += ddA_next + ddA_prev
+
+    ddt_given, dA, ddt_bias = _chunk_cumsum_bwd(
+        ddA,
+        ddt,
+        dt_in,
+        A,
+        dt_bias=dt_bias,
+        dt_softplus=dt_softplus,
+        dt_limit=dt_limit,
+        ddt=ddt_given,
+    )
+
+    return_vals = (
+        dx,
+        ddt_given,
+        dA,
+        dB_given,
+        dC_given,
+        dD,
+        dz,
+        ddt_bias,
+        dinitial_states,
+    )
+    return return_vals if not recompute_output else (*return_vals, outz)
+
+
+##### Non-CP impls. For testing and components of other impls.  #####
+
+
+class StatePassingNonCP(_StatePassingImpl):
+    @staticmethod
+    def fwd(
+        chunk_size,
+        states,
+        dA_chunk_cumsum,
+        initial_states=None,
+        seq_idx=None,
+        out_dtype=None,
+        cp_mesh: Optional[dist.device_mesh.DeviceMesh] = None,  # Intentionally unused
+    ):
+        d_state = states.shape[-1]
+        out_states, final_states = _state_passing_fwd(
+            rearrange(states, "... p n -> ... (p n)"),
+            dA_chunk_cumsum,
+            initial_states=rearrange(initial_states, "... p n -> ... (p n)")
+            if initial_states is not None
+            else None,
+            seq_idx=seq_idx,
+            chunk_size=chunk_size,
+            out_dtype=out_dtype,
+        )
+        out_states, final_states = [
+            rearrange(t, "... (p n) -> ... p n", n=d_state)
+            for t in [out_states, final_states]
+        ]
+        return out_states, final_states, None
+
+    @staticmethod
+    def bwd(
+        chunk_size: int,
+        states: torch.Tensor,
+        dA_chunk_cumsum: torch.Tensor,
+        dstates: torch.Tensor,
+        dstates_dtype: torch.dtype,
+        states_dtype: torch.dtype,
+        initial_states: Optional[torch.Tensor] = None,
+        dfinal_states: Optional[torch.Tensor] = None,
+        seq_idx: Optional[torch.Tensor] = None,
+        cp_mesh: Optional[dist.device_mesh.DeviceMesh] = None,
+        bwd_args: Optional[Any] = None,  # Intentionally unused
+    ):
+        d_state = states.shape[-1]
+        dstates_out, ddA_chunk_cumsum, dinitial_states, states = _state_passing_bwd(
+            rearrange(states, "... p n -> ... (p n)"),
+            dA_chunk_cumsum,
+            rearrange(dstates, "... p n -> ... (p n)"),
+            dfinal_states=rearrange(dfinal_states, "... p n -> ... (p n)")
+            if dfinal_states is not None
+            else None,
+            seq_idx=seq_idx,
+            has_initial_states=initial_states is not None,
+            dstates_dtype=dstates_dtype,
+            states_dtype=states_dtype,
+            chunk_size=chunk_size,
+        )
+        states = rearrange(states, "... (p n) -> ... p n", n=d_state)
+        dstates_out = rearrange(dstates_out, "... (p n) -> ... p n", n=d_state)
+        if dinitial_states is not None:
+            dinitial_states = rearrange(
+                dinitial_states, "... (p n) -> ... p n", n=d_state
+            )
+        return dstates_out, ddA_chunk_cumsum, dinitial_states, states
+
+
+mamba_chunk_scan_combined_non_cp = StatePassingNonCP.get_chunk_scan_autograd_fn()
+
+
+#### Start CP Impls ####
+
+
+class StatePassingSerialCP(_StatePassingImpl):
+    """
+    TODO: @goon - seq_idx probably not being treated correctly
+    """
+
+    @staticmethod
+    def fwd(
+        chunk_size,
+        states,
+        dA_chunk_cumsum,
+        initial_states=None,
+        seq_idx=None,
+        out_dtype=None,
+        cp_mesh: Optional[dist.device_mesh.DeviceMesh] = None,  # Unused
+    ):
+        """
+        Serially compute the final state on each rank and pass as initial_states to the next.
+        """
+        assert cp_mesh is not None
+        local_rank = cp_mesh.get_local_rank()
+        group = cp_mesh.get_group()
+        is_lead_rank = local_rank == 0
+        if not is_lead_rank and initial_states is not None:
+            raise ValueError(
+                "initial_states can only be non-trival on the lead CP rank."
+            )
+        recv_init_states = None
+        mesh_size = cp_mesh.size()
+        for send_rank, recv_rank in zip(range(mesh_size - 1), range(1, mesh_size)):
+            if local_rank == send_rank:
+                out_states, final_states, _ = StatePassingNonCP.fwd(
+                    chunk_size=chunk_size,
+                    states=states,
+                    dA_chunk_cumsum=dA_chunk_cumsum,
+                    initial_states=recv_init_states,
+                    seq_idx=seq_idx,
+                    out_dtype=out_dtype,
+                )
+
+                dist.send(
+                    final_states.contiguous(),
+                    dst=dist.get_global_rank(group, recv_rank),
+                    group=group,
+                )
+            elif local_rank == recv_rank:
+                recv_init_states = torch.empty_like(states[:, 0])
+                dist.recv(
+                    recv_init_states,
+                    src=dist.get_global_rank(group, send_rank),
+                    group=group,
+                )
+            dist.barrier()
+
+        # Final rank only:
+        if local_rank == recv_rank:
+            out_states, final_states, _ = StatePassingNonCP.fwd(
+                chunk_size=chunk_size,
+                states=states,
+                dA_chunk_cumsum=dA_chunk_cumsum,
+                initial_states=recv_init_states,
+                seq_idx=seq_idx,
+                out_dtype=out_dtype,
+            )
+        bwd_args = recv_init_states
+        return out_states, final_states, bwd_args
+
+    @staticmethod
+    def bwd(
+        chunk_size: int,
+        states: torch.Tensor,
+        dA_chunk_cumsum: torch.Tensor,
+        dstates: torch.Tensor,
+        dstates_dtype: torch.dtype,
+        states_dtype: torch.dtype,
+        initial_states: Optional[torch.Tensor] = None,
+        dfinal_states: Optional[torch.Tensor] = None,
+        seq_idx: Optional[torch.Tensor] = None,
+        cp_mesh: Optional[dist.device_mesh.DeviceMesh] = None,
+        bwd_args: Optional[Any] = None,
+    ):
+        """
+        Starting from the final rank to compute in _state_passing_serial_cp_fwd, compute
+        dinitial_states and pass these back as the dfinal_states of the preceding rank.
+        """
+        assert cp_mesh is not None
+        local_rank = cp_mesh.get_local_rank()
+        mesh_size = cp_mesh.size()
+        group = cp_mesh.get_group()
+        is_lead_rank = local_rank == 0
+        if not is_lead_rank and initial_states is not None:
+            raise ValueError(
+                "initial_states can only be non-trival on the lead CP rank."
+            )
+        is_last_rank = local_rank == mesh_size - 1
+        if not is_last_rank and dfinal_states is not None:
+            raise ValueError(
+                "dfinal_states can only be non-trival on the last CP rank."
+            )
+        recv_init_states = bwd_args
+        recv_dfinal_states = None
+        for send_rank, recv_rank in zip(
+            range(mesh_size - 1, 0, -1), range(mesh_size - 2, -1, -1)
+        ):
+            if local_rank == send_rank:
+                dstates_out, ddA_chunk_cumsum, send_dinitial_states, states = (
+                    StatePassingNonCP.bwd(
+                        chunk_size=chunk_size,
+                        states=states,
+                        dA_chunk_cumsum=dA_chunk_cumsum,
+                        dstates=dstates,
+                        initial_states=recv_init_states,
+                        dfinal_states=recv_dfinal_states,
+                        seq_idx=seq_idx,
+                        dstates_dtype=dstates_dtype,
+                        states_dtype=states_dtype,
+                        cp_mesh=cp_mesh,
+                    )
+                )
+                dist.send(
+                    send_dinitial_states.contiguous(),
+                    dst=dist.get_global_rank(group, recv_rank),
+                    group=group,
+                )
+            elif local_rank == recv_rank:
+                recv_dfinal_states = torch.empty(
+                    *states[:, 0].shape, dtype=dstates_dtype, device=states.device
+                )
+                dist.recv(
+                    recv_dfinal_states,
+                    src=dist.get_global_rank(group, send_rank),
+                    group=group,
+                )
+
+            dist.barrier()
+
+        if local_rank == recv_rank:
+            # First rank only:
+            dstates_out, ddA_chunk_cumsum, dinitial_states, states = (
+                StatePassingNonCP.bwd(
+                    chunk_size=chunk_size,
+                    states=states,
+                    dA_chunk_cumsum=dA_chunk_cumsum,
+                    dstates=dstates,
+                    initial_states=initial_states,  # Gets the original initial_states, if any
+                    dfinal_states=recv_dfinal_states,
+                    seq_idx=seq_idx,
+                    dstates_dtype=dstates_dtype,
+                    states_dtype=states_dtype,
+                    cp_mesh=cp_mesh,
+                )
+            )
+        else:
+            # Only the first rank potentially had non-trivial initial_states as proper inputs, so
+            # all other ranks get dinitial_state = None.
+            dinitial_states = None
+        return dstates_out, ddA_chunk_cumsum, dinitial_states, states
+
+
+mamba_chunk_scan_combined_serial_cp = StatePassingSerialCP.get_chunk_scan_autograd_fn()
+
+
+class StatePassingAllGatherCP(_StatePassingImpl):
+    """
+    TODO: @goon - seq_idx probably not being treated correctly
+    """
+
+    @staticmethod
+    def fwd(
+        chunk_size,
+        states,
+        dA_chunk_cumsum,
+        initial_states=None,
+        seq_idx=None,
+        out_dtype=None,
+        cp_mesh: Optional[dist.device_mesh.DeviceMesh] = None,  # Unused
+    ):
+        """
+        1. Every rank completes its _state_passing_fwd with initial_sates = None.
+        2. final_state and dA_cumsum.sum(dim=-1) all-gathered across ranks
+        3. The above data can be passed through _state_passing_fwd again to get the corrected
+           initial_states that each rank should have started with.
+        4. Every rank computes its _state_passing_fwd again, now with its proper initial_states
+        """
+        assert cp_mesh is not None
+        local_rank = cp_mesh.get_local_rank()
+        is_lead_rank = local_rank == 0
+        if not is_lead_rank and initial_states is not None:
+            raise ValueError(
+                "initial_states can only be non-trival on the lead CP rank."
+            )
+
+        # Start communicating info for later
+        dA_chunk_sum = dA_chunk_cumsum.sum(dim=-1)
+        dA_chunk_sum_allgather = torch.empty(
+            cp_mesh.size(),
+            *dA_chunk_sum.shape,
+            device=dA_chunk_sum.device,
+            dtype=dA_chunk_sum.dtype,
+        )
+        dA_comms_handle = dist.all_gather_into_tensor(
+            dA_chunk_sum_allgather,
+            dA_chunk_sum.contiguous(),
+            group=cp_mesh.get_group(),
+            async_op=True,
+        )
+
+        # Compute the partial states with the locally available information. I.e. use trivial
+        # initial_states on all but, maybe, the lead rank.
+        states_partial, final_states_partial, _ = StatePassingNonCP.fwd(
+            chunk_size=chunk_size,
+            states=states,
+            dA_chunk_cumsum=dA_chunk_cumsum,
+            initial_states=initial_states,
+            seq_idx=seq_idx,
+            out_dtype=out_dtype,
+        )
+
+        final_states_partial_allgather = torch.empty(
+            cp_mesh.size(),
+            *final_states_partial.shape,
+            device=final_states_partial.device,
+            dtype=final_states_partial.dtype,
+        )
+        dist.all_gather_into_tensor(
+            final_states_partial_allgather,
+            final_states_partial.contiguous(),
+            group=cp_mesh.get_group(),
+            async_op=False,
+        )
+
+        final_states_partial_allgather = rearrange(
+            final_states_partial_allgather, "r b ... -> b r ... "
+        )
+        dA_comms_handle.wait()
+        dA_chunk_sum_allgather = rearrange(
+            dA_chunk_sum_allgather, "r ... -> ... r"
+        ).contiguous()
+
+        # TODO: @goon - write a more focused kernel for this step.
+        if is_lead_rank:
+            initial_states_corrected = initial_states
+            final_states = final_states_partial
+            out_states = states_partial
+        else:
+            # Build the initial_states that each rank should have started with.
+            states_slice = final_states_partial_allgather[
+                :, : cp_mesh.get_local_rank()
+            ].contiguous()
+            dA_chunk_cumsum_slice = dA_chunk_sum_allgather[
+                ..., : cp_mesh.get_local_rank()
+            ].contiguous()
+            _, initial_states_corrected, _ = StatePassingNonCP.fwd(
+                chunk_size=cp_mesh.size(),
+                states=states_slice,
+                dA_chunk_cumsum=dA_chunk_cumsum_slice,
+                initial_states=None,
+                seq_idx=seq_idx,
+                out_dtype=out_dtype,
+            )
+
+            # And repeat the forward with the now-corrected initial_states
+            out_states, final_states, _ = StatePassingNonCP.fwd(
+                chunk_size=chunk_size,
+                states=states,
+                dA_chunk_cumsum=dA_chunk_cumsum,
+                initial_states=initial_states_corrected,
+                seq_idx=seq_idx,
+                out_dtype=out_dtype,
+            )
+
+        bwd_args = (initial_states_corrected, dA_chunk_sum_allgather)
+
+        return out_states, final_states, bwd_args
+
+    @staticmethod
+    def bwd(
+        chunk_size: int,
+        states: torch.Tensor,
+        dA_chunk_cumsum: torch.Tensor,
+        dstates: torch.Tensor,
+        dstates_dtype: torch.dtype,
+        states_dtype: torch.dtype,
+        initial_states: Optional[torch.Tensor] = None,
+        dfinal_states: Optional[torch.Tensor] = None,
+        seq_idx: Optional[torch.Tensor] = None,
+        cp_mesh: Optional[dist.device_mesh.DeviceMesh] = None,
+        bwd_args: Optional[Any] = None,
+    ):
+        """
+        1. Every rank completes its _state_passing_bwd with dfinal_states = None (except maybe on
+            the final cp rank) and with the corrected initial_states from the forward.
+        2. Allgather dfinal_states and use these to compute what the proper dfinal_states should
+        have been on each rank
+        3. Every rank recomputes its _state_passing_bwd with the proper {dfinal,initial}_states
+        values.
+        """
+        assert cp_mesh is not None
+        local_rank = cp_mesh.get_local_rank()
+        is_lead_rank = local_rank == 0
+        if not is_lead_rank and initial_states is not None:
+            raise ValueError(
+                "initial_states can only be non-trival on the lead CP rank."
+            )
+        is_last_rank = local_rank == cp_mesh.size() - 1
+        if not is_last_rank and dfinal_states is not None:
+            raise ValueError(
+                "dfinal_states can only be non-trival on the last CP rank."
+            )
+
+        assert bwd_args is not None
+        initial_states_corrected, dA_chunk_sum_allgather = bwd_args
+
+        # Compute dinitial_states with the locally available information. I.e. use trivial
+        # dfinal_states on all but, maybe, the last rank. These can be used to compute the
+        # corrected dfinal_states each rank should have started with.
+        dstates_partial, ddA_chunk_cumsum_partial, dinitial_states_partial, _ = (
+            StatePassingNonCP.bwd(
+                chunk_size=chunk_size,
+                states=states,
+                dA_chunk_cumsum=dA_chunk_cumsum,
+                dstates=dstates,
+                # HACK: initial_states=True ensures dinitial_states_partial is never None, maybe
+                # just zeros
+                initial_states=True,
+                dfinal_states=dfinal_states,
+                seq_idx=seq_idx,
+                dstates_dtype=dstates_dtype,
+                states_dtype=states_dtype,
+                cp_mesh=cp_mesh,
+            )
+        )
+
+        dinitial_states_partial_allgather = torch.empty(
+            cp_mesh.size(),
+            *dinitial_states_partial.shape,
+            device=dinitial_states_partial.device,
+            dtype=dinitial_states_partial.dtype,
+        )
+        dist.all_gather_into_tensor(
+            dinitial_states_partial_allgather,
+            dinitial_states_partial.contiguous(),
+            group=cp_mesh.get_group(),
+            async_op=False,
+        )
+        dinitial_states_partial_allgather = rearrange(
+            dinitial_states_partial_allgather, "r b ... -> b r ... "
+        )
+
+        # TODO: @goon - write a more focused kernel for this step.
+        if is_last_rank:
+            dinitial_states = None
+            dstates_out = dstates_partial
+            ddA_chunk_cumsum = ddA_chunk_cumsum_partial
+        else:
+            # Build the dfinal_states that each rank should have started with.
+            dstates_slice = dinitial_states_partial_allgather[
+                :, cp_mesh.get_local_rank() + 1 :
+            ]
+            dA_chunk_cumsum_slice = dA_chunk_sum_allgather[
+                ..., cp_mesh.get_local_rank() + 1 :
+            ]
+            _, _, dfinal_states_corrected, _ = StatePassingNonCP.bwd(
+                chunk_size=chunk_size,
+                # `states` is not used, but can't be None and it needs to pass shape checks
+                states=dstates_slice,
+                dA_chunk_cumsum=dA_chunk_cumsum_slice,
+                dstates=dstates_slice,
+                # HACK: initial_states=True ensures dfinal_states_corrected is never None, maybe
+                # just zeros
+                initial_states=True,
+                dfinal_states=dfinal_states,
+                seq_idx=seq_idx,
+                dstates_dtype=dstates_dtype,
+                states_dtype=states_dtype,
+                cp_mesh=cp_mesh,
+            )
+
+            # And repeat the backward with the now-corrected dfinal_states
+            dstates_out, ddA_chunk_cumsum, dinitial_states, states = (
+                StatePassingNonCP.bwd(
+                    chunk_size=chunk_size,
+                    states=states,
+                    dA_chunk_cumsum=dA_chunk_cumsum,
+                    dstates=dstates,
+                    initial_states=initial_states_corrected,
+                    dfinal_states=dfinal_states_corrected,
+                    seq_idx=seq_idx,
+                    dstates_dtype=dstates_dtype,
+                    states_dtype=states_dtype,
+                    cp_mesh=cp_mesh,
+                )
+            )
+
+            # Only the first rank potentially had non-trivial initial_states as proper inputs, so
+            # all other ranks get dinitial_states = None.
+            if not is_lead_rank:
+                dinitial_states = None
+        return dstates_out, ddA_chunk_cumsum, dinitial_states, states
+
+
+mamba_chunk_scan_combined_allgather_cp = (
+    StatePassingAllGatherCP.get_chunk_scan_autograd_fn()
+)

--- a/mamba_ssm/ops/triton/ssd_combined_cp.py
+++ b/mamba_ssm/ops/triton/ssd_combined_cp.py
@@ -718,7 +718,6 @@ class StatePassingSerialCP(_StatePassingImpl):
                     src=dist.get_global_rank(group, send_rank),
                     group=group,
                 )
-            dist.barrier()
 
         # Final rank only:
         if local_rank == recv_rank:
@@ -799,8 +798,6 @@ class StatePassingSerialCP(_StatePassingImpl):
                     src=dist.get_global_rank(group, send_rank),
                     group=group,
                 )
-
-            dist.barrier()
 
         if local_rank == recv_rank:
             # First rank only:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "transformers",
     "packaging",
     "setuptools>=61.0.0",
+    "ring-flash-attn"
 ]
 [project.urls]
 Repository = "https://github.com/state-spaces/mamba"

--- a/setup.py
+++ b/setup.py
@@ -188,6 +188,9 @@ if not SKIP_CUDA_BUILD:
         if bare_metal_version >= Version("11.8"):
             cc_flag.append("-gencode")
             cc_flag.append("arch=compute_90,code=sm_90")
+        if bare_metal_version >= Version("12.8"):
+            cc_flag.append("-gencode")
+            cc_flag.append("arch=compute_100,code=sm_100")
 
 
     # HACK: The compiler flag -D_GLIBCXX_USE_CXX11_ABI is set to be the same as

--- a/tests/mamba_cp/profile_single_mamba_layer_fwd.py
+++ b/tests/mamba_cp/profile_single_mamba_layer_fwd.py
@@ -1,0 +1,137 @@
+import json
+import os
+import subprocess
+from argparse import ArgumentParser
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.profiler import ProfilerActivity, profile
+
+from mamba_ssm.modules.mamba2_cp import Mamba2CP
+
+
+def trace_handler(prof):
+    global impl
+    global args
+    global model
+    global rank
+    global world_size
+
+    trace_ranks = {int(r) % world_size for r in args.trace_ranks.split(",")}
+    if rank not in trace_ranks:
+        return
+
+    print(
+        prof.key_averages().table(
+            sort_by="cuda_time_total",
+            row_limit=20,
+            header=f"{impl=}",
+        )
+    )
+    trace_dir = Path(args.trace_dir)
+    timestamp = datetime.now().strftime("%y%m%d_%H%M")
+
+    subdir = trace_dir.joinpath(f"world_{world_size}/{timestamp}/")
+    subdir.mkdir(parents=True, exist_ok=True)
+    seq = args.seq_len_per_gpu * world_size
+    filename = f"trace_{impl}_step_{prof.step_num}_rank_{rank}_bsz_{args.batch_size}_seq_{seq}_layers_{args.n_layers}.json"
+
+    prof.export_chrome_trace(str(subdir.joinpath(f"{filename}")))
+    if not rank:
+        with open(subdir.joinpath(f"args_{impl}.json"), "w") as fp:
+            json.dump(vars(args), fp)
+        short_hash = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"], capture_output=True, text=True
+        ).stdout.strip()
+        with open(subdir.joinpath(short_hash), "w") as _:
+            pass
+
+
+if __name__ == "__main__":
+    # torchrun specific
+    local_rank = int(os.environ["LOCAL_RANK"])
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+
+    dtype = torch.bfloat16
+    device = torch.device(f"cuda:{local_rank}")
+    # some setups
+    torch.cuda.set_device(local_rank)
+    try:
+        dist.init_process_group(
+            backend="nccl", timeout=timedelta(seconds=60), device_id=device
+        )
+        mesh = dist.device_mesh.init_device_mesh("cuda", (world_size,))
+
+        os.environ["TORCH_SHOW_CPP_STACKTRACES"] = str(1)
+        os.environ["TORCH_NCCL_ASYNC_ERROR_HANDLING"] = str(1)
+
+        parser = ArgumentParser()
+        parser.add_argument("--active", type=int, default=2)
+        parser.add_argument("--batch_size", type=int, default=1)
+        parser.add_argument("--d_model", type=int, default=4096)  # bamba 9.8b default
+        parser.add_argument("--impls", type=str, default="allgather,serial")
+        parser.add_argument("--iters", type=int, default=50)
+        parser.add_argument("--repeat", type=int, default=2)
+        parser.add_argument("--n_layers", type=int, default=10)
+        parser.add_argument("--seq_len_per_gpu", type=int, default=65536)
+        parser.add_argument("--trace_dir", default="/dev/null")
+        parser.add_argument("--trace_ranks", type=str, default="0,-1")
+        parser.add_argument("--wait", type=int, default=3)
+        parser.add_argument("--warmup", type=int, default=3)
+
+        args = parser.parse_args()
+        impls = args.impls.split(",")
+        iters_per_impl = args.repeat * (args.active + args.wait + args.warmup)
+
+        if rank == 0:
+            print(f"--> running with these configs {args}")
+
+        inputs = torch.randn(
+            args.batch_size,
+            args.seq_len_per_gpu,
+            args.d_model,
+            device=device,
+            dtype=dtype,
+        )
+
+        for impl in impls:
+            mamba_stack = nn.Sequential(
+                *[
+                    Mamba2CP(
+                        d_model=args.d_model,
+                        cp_mesh=mesh,
+                        cp_mamba_impl=impl,
+                        device=device,
+                        dtype=dtype,
+                    )
+                    for _ in range(args.n_layers)
+                ]
+            )
+
+            with (
+                profile(
+                    activities=[ProfilerActivity.CUDA, ProfilerActivity.CPU],
+                    # record_shapes=True,
+                    # with_stack=True,
+                    # profile_memory=True,
+                    schedule=torch.profiler.schedule(
+                        wait=args.wait,
+                        warmup=args.warmup,
+                        active=args.active,
+                        repeat=args.repeat,
+                    ),
+                    on_trace_ready=trace_handler,
+                ) as prof,
+                torch.no_grad(),
+            ):
+                for _ in range(iters_per_impl):
+                    mamba_stack(inputs)
+                    prof.step()
+            del mamba_stack
+
+    finally:
+        dist.destroy_process_group()

--- a/tests/mamba_cp/test_d_grads_single_gpu.py
+++ b/tests/mamba_cp/test_d_grads_single_gpu.py
@@ -1,0 +1,77 @@
+import torch
+import torch.nn.functional as F
+
+from mamba_ssm.models.config_mamba import MambaConfig
+from mamba_ssm.models.mixer_seq_simple import MambaLMHeadModel
+
+"""
+To run in a loop until a failure is hit:
+
+```
+while python3 tests/mamba_cp/test_d_grads_single_gpu.py; do :; done
+```
+"""
+
+if __name__ == "__main__":
+    torch.manual_seed(42)
+    batch_size = 4
+    device = torch.device("cuda")
+    torch.cuda.set_device(0)
+
+    d_model = 256
+    expand = 2
+    d_conv = 4
+    head_dim = 64
+    num_heads = d_model // head_dim
+    dtype = torch.bfloat16
+    ssm_cfg = {"layer": "Mamba2"}
+    vocab_size = 1024
+    n_layer = 2
+    attn_layer_idx = [n_layer - 1]
+    attn_cfg = {
+        "causal": True,
+        "d_conv": 0,
+        "head_dim": head_dim,
+        "num_heads": num_heads,
+        "out_proj_bias": False,
+        "qkv_proj_bias": False,
+        "rotary_emb_dim": head_dim // 2,
+    }
+    cfg = MambaConfig(
+        d_model=d_model,
+        n_layer=n_layer,
+        vocab_size=vocab_size,
+        ssm_cfg=ssm_cfg,
+        attn_layer_idx=attn_layer_idx,
+        attn_cfg=attn_cfg,
+        tie_embeddings=False,
+    )
+    seq_len = 32
+
+    model = MambaLMHeadModel(config=cfg, device=device, dtype=dtype)
+    inputs = torch.randint(vocab_size, size=(batch_size, seq_len), device=device)
+    grads_old = None
+    fails = {}
+    for i in range(10):
+        outputs = model(inputs).logits
+        loss = F.cross_entropy(
+            outputs.reshape(-1, outputs.size(-1)), inputs.reshape(-1).long()
+        )
+        loss.backward()
+        grads_new = {
+            n: p.grad for n, p in model.named_parameters() if p.grad is not None
+        }
+        if grads_old is not None:
+            for n, grad in grads_new.items():
+                if not torch.allclose(grad, grads_old[n]):
+                    fails[n] = [grad, grads_old[n]]
+        if fails:
+            print(f"FAILED on iteration {i}")
+            for n, (grad_new, grad_old) in fails.items():
+                print(f"{n=}\n\t{grad_new=}\n\t{grad_old=}")
+            raise RuntimeError
+        model.zero_grad()
+        torch.cuda.synchronize()
+        grads_old = grads_new
+        if i:
+            print(f"PASSED on iteration {i}")

--- a/tests/mamba_cp/test_d_grads_single_gpu.py
+++ b/tests/mamba_cp/test_d_grads_single_gpu.py
@@ -65,6 +65,8 @@ if __name__ == "__main__":
             for n, grad in grads_new.items():
                 if not torch.allclose(grad, grads_old[n]):
                     fails[n] = [grad, grads_old[n]]
+                else:
+                    print(f"{n=} passed")
         if fails:
             print(f"FAILED on iteration {i}")
             for n, (grad_new, grad_old) in fails.items():

--- a/tests/mamba_cp/test_fake_cp.py
+++ b/tests/mamba_cp/test_fake_cp.py
@@ -1,0 +1,433 @@
+from copy import deepcopy
+
+import torch
+from einops import rearrange
+
+from mamba_ssm.modules.mamba2 import Mamba2
+from mamba_ssm.modules.mamba2_cp import conv, _Mamba2Ref
+from mamba_ssm.ops.triton.ssd_state_passing import (
+    _state_passing_fwd,
+    _state_passing_bwd,
+)
+
+try:
+    from causal_conv1d import causal_conv1d_fn
+except ImportError:
+    causal_conv1d_fn = None
+
+
+# Breaking out various parts of the fwd for easier testing:
+
+
+class _TestBase:
+    batch_size = 2
+    cp_dim = 4
+    chunk_size = 4
+    seq_len = 4 * cp_dim * chunk_size
+    n_chunks = seq_len // chunk_size
+    d_model = 256
+    d_state = 128
+    ngroups = 1
+    expand = 2
+    headdim = 64
+    d_conv = 4
+    d_inner = expand * d_model
+    d_ssm = d_inner
+    dtype = (
+        torch.float32
+    )  # Important: makes verifying correctness much easier than bfloat16
+    device = "cuda"
+    factory_kwargs = {"device": device, "dtype": dtype}
+    model_kwargs = {
+        "d_model": d_model,
+        "d_state": d_state,
+        "chunk_size": chunk_size,
+        "ngroups": ngroups,
+        "headdim": headdim,
+        "d_conv": d_conv,
+        "device": device,
+        "dtype": dtype,
+    }
+
+    def get_mamba2(self, seed: int = 42) -> Mamba2:
+        torch.manual_seed(seed)
+        return Mamba2(**self.model_kwargs)
+
+    def get_mamba2_ref(self, seed: int = 42) -> _Mamba2Ref:
+        torch.manual_seed(seed)
+        return _Mamba2Ref(**self.model_kwargs)
+
+    def get_inputs(self, requires_grad: bool = False, seed: int = 42) -> torch.Tensor:
+        torch.manual_seed(seed)
+        return torch.randn(
+            self.batch_size,
+            self.seq_len,
+            self.d_model,
+            **self.factory_kwargs,
+            requires_grad=requires_grad,
+        )
+
+    def get_xBC(self, requires_grad: bool = False) -> torch.Tensor:
+        return torch.randn(
+            self.batch_size,
+            self.seq_len,
+            self.d_ssm + 2 * self.ngroups * self.d_state,
+            **self.factory_kwargs,
+            requires_grad=requires_grad,
+        )
+
+    def get_states_dA_chunk_cumum(
+        self, requires_grad: bool = False
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        n_heads = self.d_model * self.expand // self.headdim
+        states = torch.randn(
+            self.batch_size,
+            self.n_chunks,
+            n_heads,
+            self.headdim,
+            **self.factory_kwargs,
+            requires_grad=requires_grad,
+        )
+        dA_chunk_cumsum = torch.randn(
+            self.batch_size,
+            n_heads,
+            self.n_chunks,
+            **self.factory_kwargs,
+            requires_grad=requires_grad,
+        )
+        return states, dA_chunk_cumsum
+
+
+class Test_Mamba2Ref(_TestBase):
+    def test_fwd(self) -> None:
+        mamba2 = self.get_mamba2()
+        mamba2_ref = self.get_mamba2_ref()
+        inputs = self.get_inputs()
+        outputs = mamba2(inputs)
+        outputs_copy = mamba2_ref(inputs)
+        torch.testing.assert_close(outputs, outputs_copy)
+
+    def test_bwd(self) -> None:
+        mamba2 = self.get_mamba2()
+        mamba2_copy = self.get_mamba2_ref()
+        inputs = self.get_inputs(requires_grad=True)
+        inputs_copy = deepcopy(inputs)
+        mamba2(inputs).sum().backward()
+        mamba2_copy(inputs_copy).sum().backward()
+
+        for p1, p2 in zip(mamba2.parameters(), mamba2_copy.parameters()):
+            if p1.grad is not None:
+                torch.testing.assert_close(p1.grad, p2.grad)
+        torch.testing.assert_close(inputs.grad, inputs_copy.grad)
+
+
+class TestLocalCP(_TestBase):
+    """
+    Single-device mock ups of CP implementations, and other related tests.
+    """
+
+    def test_conv_with_state_fwd(self) -> None:
+        torch.manual_seed(42)
+        xBC = self.get_xBC()
+
+        # Shard and create the conv states
+        xBC_cp = rearrange(xBC, "b (c l) d -> b l d c ", c=self.cp_dim)
+        xBC_cp_conv_states = xBC_cp[:, -(self.d_conv - 1) :]
+        xBC_cp_conv_states = xBC_cp_conv_states.roll(1, dims=-1)
+        # First conv state is trivial (could also make it None)
+        xBC_cp_conv_states[..., 0] = 0.0
+
+        outputs = conv(xBC, self.get_mamba2())
+        outputs_cp_list: list[torch.Tensor] = []
+        for rank_cp in range(self.cp_dim):
+            cp_out = conv(
+                xBC_cp[..., rank_cp],
+                mamba2=self.get_mamba2(),
+                conv_state=xBC_cp_conv_states[..., rank_cp],
+            )
+            outputs_cp_list.append(cp_out)
+        outputs_cp = torch.cat(outputs_cp_list, dim=1)
+        torch.testing.assert_close(outputs, outputs_cp)
+
+    def test_conv_with_state_bwd(self) -> None:
+        torch.manual_seed(42)
+        xBC = self.get_xBC(requires_grad=True)
+        torch.manual_seed(42)
+        xBC_clone = self.get_xBC(requires_grad=True)
+
+        mamba2 = self.get_mamba2()
+        mamba2_cp = deepcopy(mamba2)
+
+        # Shard and create the conv states
+        xBC_cp = rearrange(xBC_clone, "b (r l) d -> b l d r ", r=self.cp_dim)
+        xBC_cp_conv_states = xBC_cp[:, -(self.d_conv - 1) :]
+
+        outputs = conv(xBC, mamba2)
+        outputs.sum().backward()
+
+        for rank_cp in range(self.cp_dim):
+            cp_out = conv(
+                xBC_cp[..., rank_cp],
+                mamba2=mamba2_cp,
+                conv_state=None
+                if not rank_cp
+                else xBC_cp_conv_states[..., rank_cp - 1],
+            )
+            cp_out.sum().backward()
+        for p1, p2 in zip(mamba2.parameters(), mamba2_cp.parameters()):
+            torch.testing.assert_close(p1, p2)
+        tol = 5e-3
+        torch.testing.assert_close(xBC.grad, xBC_clone.grad, atol=tol, rtol=tol)
+
+    def test_chunked_state_passing_sequential_fwd(self) -> None:
+        """
+        Simulated CP with serial state_passing step:
+        - Rank 0 completes its state_passing with initial_sates = None, then passes final_state to
+          Rank 1.
+        - Rank 1 completes its state_passing using the received final_state as its initial_state,
+          and passes the new final_state to Rank 2
+        - ...
+        - The last rank completes its state_passing using the received final_state as its
+          initial_state.
+
+        NOTE: omits the d_state dim
+        """
+        torch.manual_seed(42)
+        states, dA_chunk_cumsum = self.get_states_dA_chunk_cumum()
+
+        # Shard
+        states_cp = rearrange(states, "b (r c) h p -> b c h p r", r=self.cp_dim)
+        dA_chunk_cumsum_cp = rearrange(
+            dA_chunk_cumsum, "b h (r c) -> b h c r ", r=self.cp_dim
+        )
+
+        # Ground truth
+        out, final_state = _state_passing_fwd(states, dA_chunk_cumsum)
+
+        out_cp_list = []
+        initial_states = None
+        # Step through ranks serially, one passing their final states as the initial states of the
+        # next rank.
+        for rank_cp in range(self.cp_dim):
+            out_cp, initial_states = _state_passing_fwd(
+                states_cp[..., rank_cp],
+                dA_chunk_cumsum_cp[..., rank_cp],
+                initial_states,
+            )
+            out_cp_list.append(out_cp)
+        out_cp = torch.cat(out_cp_list, dim=1)
+        torch.testing.assert_close(out, out_cp)
+        torch.testing.assert_close(final_state, initial_states)
+
+    def test_chunked_state_passing_sequential_bwd(self) -> None:
+        """
+        Simulated CP with serial state_passing step:
+        - Rank 0 completes its state_passing with initial_sates = None, then passes final_state to
+          Rank 1.
+        - Rank 1 completes its state_passing using the received final_state as its initial_state,
+          and passes the new final_state to Rank 2
+        - ...
+        - The last rank completes its state_passing using the received final_state as its
+          initial_state.
+
+        NOTE: omits the d_state dim
+        """
+        torch.manual_seed(42)
+        states, dA_chunk_cumsum = self.get_states_dA_chunk_cumum()
+        dout = torch.randn_like(states)
+
+        # Shard
+        states_cp = rearrange(states, "b (r c) h p -> b c h p r", r=self.cp_dim)
+        dout_cp = rearrange(dout, "b (r c) h p -> b c h p r", r=self.cp_dim)
+        dA_chunk_cumsum_cp = rearrange(
+            dA_chunk_cumsum, "b h (r c) -> b h c r ", r=self.cp_dim
+        )
+
+        # Ground truth
+        dstates, ddA_chunk_cumsum, *_ = _state_passing_bwd(
+            states,
+            dA_chunk_cumsum,
+            dout,
+            dfinal_states=None,
+            has_initial_states=True,
+            dstates_dtype=states.dtype,
+            states_dtype=states.dtype,
+        )
+
+        dstates_cp_list = []
+        ddA_chunk_cumsum_cp_list = []
+        dfinal_states = None
+        # Step through ranks serially in reversed order, one passing their dinitstates as the
+        # dfinal_states of the preceding rank.
+        for rank_cp in reversed(range(self.cp_dim)):
+            dstates_cp, ddA_chunk_cumsum_cp, dfinal_states, _ = _state_passing_bwd(
+                states_cp[..., rank_cp],
+                dA_chunk_cumsum_cp[..., rank_cp],
+                dout_cp[..., rank_cp],
+                dfinal_states=dfinal_states,
+                has_initial_states=True,
+                dstates_dtype=states.dtype,
+                states_dtype=states.dtype,
+            )
+            dstates_cp_list.append(dstates_cp)
+            ddA_chunk_cumsum_cp_list.append(ddA_chunk_cumsum_cp)
+        dstates_cp = torch.cat(list(reversed(dstates_cp_list)), dim=1)
+        ddA_chunk_cumsum_cp = torch.cat(
+            list(reversed(ddA_chunk_cumsum_cp_list)), dim=-1
+        )
+        tol = 1e-3
+        torch.testing.assert_close(dstates, dstates_cp)
+        torch.testing.assert_close(
+            ddA_chunk_cumsum, ddA_chunk_cumsum_cp, atol=tol, rtol=tol
+        )
+
+    def test_chunked_state_passing_allgather_fwd(self) -> None:
+        """
+        Simulated CP with more parallelized state_passing step:
+        - Every rank completes its _state_passing_fwd with initial_sates = None to get its
+          final_state
+        - final_state and dA_cumsum.sum(dim=-1) all-gathered across ranks
+        - The above data can be passed through _state_passing_fwd again to get the corrected
+          initial_states on each rank.
+        - Finally, every rank computes its _state_passing_fwd again, now with its proper
+          initial_states
+        NOTE: omits the d_state dim
+        """
+        torch.manual_seed(42)
+        states, dA_chunk_cumsum = self.get_states_dA_chunk_cumum()
+        # states: (b, c, h, p)
+        # dA_chunk_cumsum: (b, h, c)
+
+        # Shard and create the conv states
+        states_cp = rearrange(states, "b (r c) h p -> b c h p r", r=self.cp_dim)
+        dA_chunk_cumsum_cp = rearrange(
+            dA_chunk_cumsum, "b h (r c) -> b h c r ", r=self.cp_dim
+        )
+
+        # Ground truth
+        out, _ = _state_passing_fwd(states, dA_chunk_cumsum)
+
+        # Compute the states local to each rank (trivial initial_states)
+        final_state_cp_list = []
+        for rank_cp in range(self.cp_dim):
+            _, final_state_cp = _state_passing_fwd(
+                states_cp[..., rank_cp],
+                dA_chunk_cumsum_cp[..., rank_cp],
+            )
+            final_state_cp_list.append(final_state_cp)
+
+        # Simulate all-gathering the final states and summed dA_chunk_cumsum_cp per rank.
+        final_states_allgather = torch.stack(final_state_cp_list, dim=1)
+        # Important! Do the sum in float32, otherwise the tests won't pass due to numerics
+        dA_chunk_sum_allgather = dA_chunk_cumsum_cp.to(torch.float32).sum(dim=2)
+
+        # Locally compute state passing on the final states. These define what would logically be
+        # the proper initial states that every rank should have started with.
+        initial_states_cp, _ = _state_passing_fwd(
+            final_states_allgather,
+            dA_chunk_sum_allgather,
+        )
+        initial_states_cp = rearrange(initial_states_cp, "b r h p -> b h p r")
+
+        # Then recompute the out states with the now-known initial states.
+        out_cp_list: list[torch.Tensor] = []
+        for rank_cp in range(self.cp_dim):
+            out_cp, _ = _state_passing_fwd(
+                states_cp[..., rank_cp],
+                dA_chunk_cumsum_cp[..., rank_cp],
+                initial_states_cp[..., rank_cp],
+            )
+            out_cp_list.append(out_cp)
+        out_cp = torch.stack(out_cp_list, dim=-1)
+        out_cp = rearrange(out_cp, "b c h p r -> b (r c) h p")
+
+        tol = 1e-3
+        torch.testing.assert_close(out, out_cp, atol=tol, rtol=tol)
+
+    def test_chunked_state_passing_allgather_bwd(self) -> None:
+        """
+        Simulated CP with more parallelized state_passing step:
+        - Every rank completes its _state_passing_bwd with dfinal_states = None to get its
+          dinitial_state
+        - dinitial_state and dA_cumsum.sum(dim=-1) all-gathered across ranks
+        - The above data can be passed through _state_passing_fwd again to get the corrected
+          dfinal_states on each rank.
+        - Finally, every rank computes its _state_passing_bwd again, now with its proper
+          dfinal_states
+        NOTE: omits the d_state dim
+        """
+        states, dA_chunk_cumsum = self.get_states_dA_chunk_cumum()
+        dout = torch.randn_like(states)
+
+        # Shard
+        states_cp = rearrange(states, "b (r c) h p -> b c h p r", r=self.cp_dim)
+        dout_cp = rearrange(dout, "b (r c) h p -> b c h p r", r=self.cp_dim)
+        dA_chunk_cumsum_cp = rearrange(
+            dA_chunk_cumsum, "b h (r c) -> b h c r ", r=self.cp_dim
+        )
+
+        # Ground truth
+        dstates, ddA_chunk_cumsum, *_ = _state_passing_bwd(
+            states,
+            dA_chunk_cumsum,
+            dout,
+            dfinal_states=None,
+            has_initial_states=True,
+            dstates_dtype=states.dtype,
+            states_dtype=states.dtype,
+        )
+
+        # Run the backwards with only local data (i.e. with the incorrect dfinal_states = None)
+        dinitstates_cp_list = []
+        for rank_cp in range(self.cp_dim):
+            _, _, dinitstates_cp, *_ = _state_passing_bwd(
+                states_cp[..., rank_cp],
+                dA_chunk_cumsum_cp[..., rank_cp],
+                dout_cp[..., rank_cp],
+                dfinal_states=None,
+                has_initial_states=True,
+                dstates_dtype=states.dtype,
+                states_dtype=states.dtype,
+            )
+            dinitstates_cp_list.append(dinitstates_cp)
+
+        # Simulate all-gathering the dinitstates and summed dA_chunk_cumsum_cp per rank.
+        dinitstates_allgather = torch.stack(dinitstates_cp_list, dim=1)
+        # Important! Do the sum in float32, otherwise the tests won't pass due to numerics
+        dA_chunk_sum_allgather = dA_chunk_cumsum_cp.to(torch.float32).sum(dim=2)
+
+        # Run another backwards to turn the dinitstates into the correct dfinal_states for each rank
+        dfinal_states_cp, *_ = _state_passing_bwd(
+            torch.empty_like(dinitstates_allgather),  # Not used, but can't be None
+            dA_chunk_sum_allgather,
+            dinitstates_allgather,
+            dfinal_states=None,
+            has_initial_states=True,
+            dstates_dtype=states.dtype,
+            states_dtype=states.dtype,
+        )
+        dfinal_states_cp = rearrange(dfinal_states_cp, "b r h p -> b h p r")
+
+        # Then recompute derivatives with the now-known dfinal_states states.
+        dstates_cp_list = []
+        ddA_chunk_cumsum_cp_list = []
+        for rank_cp in range(self.cp_dim):
+            dstates_cp, ddA_chunk_cumsum_cp, *_ = _state_passing_bwd(
+                states_cp[..., rank_cp],
+                dA_chunk_cumsum_cp[..., rank_cp],
+                dout_cp[..., rank_cp],
+                dfinal_states=dfinal_states_cp[..., rank_cp],
+                has_initial_states=True,
+                dstates_dtype=states.dtype,
+                states_dtype=states.dtype,
+            )
+            dstates_cp_list.append(dstates_cp)
+            ddA_chunk_cumsum_cp_list.append(ddA_chunk_cumsum_cp)
+
+        dstates_cp = torch.cat(dstates_cp_list, dim=1)
+        ddA_chunk_cumsum_cp = torch.cat(ddA_chunk_cumsum_cp_list, dim=2)
+        tol = 1e-3
+        torch.testing.assert_close(dstates, dstates_cp, atol=tol, rtol=tol)
+        torch.testing.assert_close(
+            ddA_chunk_cumsum, ddA_chunk_cumsum_cp, atol=tol, rtol=tol
+        )

--- a/tests/mamba_cp/test_real_cp.py
+++ b/tests/mamba_cp/test_real_cp.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Optional
+from typing import Literal, Optional
 
 import pytest
 import torch
@@ -361,10 +361,12 @@ class _DTestModelBase(DTest):
 
     def get_mha(self, seed: int = 42, dtype: torch.dtype = torch.bfloat16) -> MHA:
         torch.manual_seed(seed)
+        # Use the bamba value rotary_emb_dim=headdim//2 so that rope is non-trivial
         return MHA(
             embed_dim=self.embed_dim,
             num_heads=self.num_heads,
             causal=True,
+            rotary_emb_dim=self.head_dim // 2,
             device=self.device,
             dtype=dtype,
         )
@@ -374,14 +376,16 @@ class _DTestModelBase(DTest):
         cp_mesh: dist.device_mesh.DeviceMesh,
         seed: int = 42,
         dtype: torch.dtype = torch.bfloat16,
-        cp_attn_impl: str = "zigzag",
+        cp_attn_impl: Literal["zigzag", "ring"] = "zigzag",
     ) -> MHA:
         torch.manual_seed(seed)
+        # Use the bamba value rotary_emb_dim=headdim//2 so that rope is non-trivial
         return MHACP(
             cp_mesh=cp_mesh,
             embed_dim=self.embed_dim,
             num_heads=self.num_heads,
             causal=True,
+            rotary_emb_dim=self.head_dim // 2,
             device=self.device,
             dtype=dtype,
             cp_attn_impl=cp_attn_impl,

--- a/tests/mamba_cp/test_real_cp.py
+++ b/tests/mamba_cp/test_real_cp.py
@@ -633,8 +633,6 @@ class TestConvCP(_DTestModelBase):
         torch.testing.assert_close(
             outputs_cp,
             outputs.tensor_split(self.world_size, dim=1)[self.rank],
-            atol=self.tol,
-            rtol=self.tol,
         )
 
     def test_bwd(self):
@@ -652,8 +650,6 @@ class TestConvCP(_DTestModelBase):
         torch.testing.assert_close(
             outputs_cp,
             outputs.tensor_split(self.world_size, dim=1)[self.rank],
-            atol=self.tol,
-            rtol=self.tol,
         )
         outputs.sum().backward()
         outputs_cp.sum().backward()
@@ -661,7 +657,7 @@ class TestConvCP(_DTestModelBase):
         xBC_grad_shard = self.get_cp_shard(xBC.grad)
         xBC_cp_grad_shard = self.get_cp_shard(xBC_copy.grad)
         torch.testing.assert_close(
-            xBC_grad_shard, xBC_cp_grad_shard, atol=self.tol, rtol=self.tol
+            xBC_cp_grad_shard, xBC_grad_shard, atol=self.tol, rtol=self.tol
         )
 
 
@@ -696,7 +692,7 @@ class TestScanCP(_DTestModelBase):
             outputs_cp_all_gathered, "r b l ... -> b (r l) ..."
         )
         torch.testing.assert_close(
-            outputs, outputs_cp_all_gathered, atol=self.tol, rtol=self.tol
+            outputs_cp_all_gathered, outputs, atol=self.tol, rtol=self.tol
         )
 
     @pytest.mark.parametrize("cp_mamba_impl", ("serial", "allgather"))
@@ -726,7 +722,7 @@ class TestScanCP(_DTestModelBase):
         inputs_cp_grad_shard = self.get_cp_shard(inputs_copy.grad)
 
         torch.testing.assert_close(
-            inputs_grad_shard, inputs_cp_grad_shard, atol=self.tol, rtol=self.tol
+            inputs_cp_grad_shard, inputs_grad_shard, atol=self.tol, rtol=self.tol
         )
 
         # Parameter grads should match after all-reducing.
@@ -771,7 +767,7 @@ class TestMamba2CP(_DTestModelBase):
         inputs_grad_shard = self.get_cp_shard(inputs.grad)
         inputs_cp_grad_shard = self.get_cp_shard(inputs_copy.grad)
         torch.testing.assert_close(
-            inputs_grad_shard, inputs_cp_grad_shard, atol=self.tol, rtol=self.tol
+            inputs_cp_grad_shard, inputs_grad_shard, atol=self.tol, rtol=self.tol
         )
 
         # Parameter grads should match after all-reducing.
@@ -819,7 +815,7 @@ class TestMHACP(_DTestModelBase):
         inputs_cp_grad_shard = self.get_cp_shard(inputs_copy.grad)
         dist.barrier()
         torch.testing.assert_close(
-            inputs_grad_shard, inputs_cp_grad_shard, atol=self.tol, rtol=self.tol
+            inputs_cp_grad_shard, inputs_grad_shard, atol=self.tol, rtol=self.tol
         )
 
         # Parameter grads should match after all-reducing.
@@ -896,13 +892,13 @@ class TestFSDP1MambaCP(_DTestModelBase):
             dist.all_reduce(loss_cp_fsdp)
             mean_loss_cp_fsdp = loss_cp_fsdp / self.world_size
             torch.testing.assert_close(
-                loss, mean_loss_cp_fsdp, atol=self.tol, rtol=self.tol
+                mean_loss_cp_fsdp, loss, atol=self.tol, rtol=self.tol
             )
 
         grad_norm = nn.utils.clip_grad_norm_(model.parameters(), 1.0)
         grad_norm_cp_fsdp = model_cp_fsdp.clip_grad_norm_(1.0)
         torch.testing.assert_close(
-            grad_norm, grad_norm_cp_fsdp, atol=self.tol, rtol=self.tol
+            grad_norm_cp_fsdp, grad_norm, atol=self.tol, rtol=self.tol
         )
 
         with FSDP.summon_full_params(model_cp_fsdp, with_grads=True):
@@ -983,13 +979,13 @@ class TestFSDP1MHACP(_DTestModelBase):
             dist.all_reduce(loss_cp_fsdp)
             mean_loss_cp_fsdp = loss_cp_fsdp / self.world_size
             torch.testing.assert_close(
-                loss, mean_loss_cp_fsdp, atol=self.tol, rtol=self.tol
+                mean_loss_cp_fsdp, loss, atol=self.tol, rtol=self.tol
             )
 
         grad_norm = nn.utils.clip_grad_norm_(model.parameters(), 1.0)
         grad_norm_cp_fsdp = model_cp_fsdp.clip_grad_norm_(1.0)
         torch.testing.assert_close(
-            grad_norm, grad_norm_cp_fsdp, atol=self.tol, rtol=self.tol
+            grad_norm_cp_fsdp, grad_norm, atol=self.tol, rtol=self.tol
         )
 
         with FSDP.summon_full_params(model_cp_fsdp, with_grads=True):
@@ -1083,13 +1079,13 @@ class TestHSDP1MambaCP(_DTestModelBase):
             dist.all_reduce(loss_cp_hsdp)
             mean_loss_cp_hsdp = loss_cp_hsdp / self.world_size
             torch.testing.assert_close(
-                loss, mean_loss_cp_hsdp, atol=self.tol, rtol=self.tol
+                mean_loss_cp_hsdp, loss, atol=self.tol, rtol=self.tol
             )
 
         grad_norm = nn.utils.clip_grad_norm_(model.parameters(), 1.0)
         grad_norm_cp_hsdp = model_cp_hsdp.clip_grad_norm_(1.0)
         torch.testing.assert_close(
-            grad_norm, grad_norm_cp_hsdp, atol=self.tol, rtol=self.tol
+            grad_norm_cp_hsdp, grad_norm, atol=self.tol, rtol=self.tol
         )
 
         inputs_grad_shard = self.get_cp_hsdp_shard(inputs.grad, mesh)
@@ -1197,13 +1193,13 @@ class TestHSDP1MHACP(_DTestModelBase):
             dist.all_reduce(loss_cp_hsdp)
             mean_loss_cp_hsdp = loss_cp_hsdp / self.world_size
             torch.testing.assert_close(
-                loss, mean_loss_cp_hsdp, atol=self.tol, rtol=self.tol
+                mean_loss_cp_hsdp, loss, atol=self.tol, rtol=self.tol
             )
 
         grad_norm = nn.utils.clip_grad_norm_(model.parameters(), 1.0)
         grad_norm_cp_hsdp = model_cp_hsdp.clip_grad_norm_(1.0)
         torch.testing.assert_close(
-            grad_norm, grad_norm_cp_hsdp, atol=self.tol, rtol=self.tol
+            grad_norm_cp_hsdp, grad_norm, atol=self.tol, rtol=self.tol
         )
 
         inputs_grad_shard = self.get_cp_hsdp_shard(inputs.grad, mesh)
@@ -1290,13 +1286,13 @@ class TestModelCPFSDP1(_DTestModelBase):
             dist.all_reduce(loss_cp_fsdp)
             mean_loss_cp_fsdp = loss_cp_fsdp / self.world_size
             torch.testing.assert_close(
-                loss, mean_loss_cp_fsdp, atol=self.tol, rtol=self.tol
+                mean_loss_cp_fsdp, loss, atol=self.tol, rtol=self.tol
             )
 
         grad_norm = nn.utils.clip_grad_norm_(model.parameters(), 1.0)
         grad_norm_cp_fsdp = model_cp_fsdp.clip_grad_norm_(1.0)
         torch.testing.assert_close(
-            grad_norm, grad_norm_cp_fsdp, atol=self.tol, rtol=self.tol
+            grad_norm_cp_fsdp, grad_norm, atol=self.tol, rtol=self.tol
         )
 
         with FSDP.summon_full_params(model_cp_fsdp, with_grads=True):
@@ -1368,7 +1364,7 @@ class TestModelCPFSDP2(_DTestModelBase):
             dist.all_reduce(loss_cp_fsdp)
             mean_loss_cp_fsdp = loss_cp_fsdp / self.world_size
             torch.testing.assert_close(
-                loss, mean_loss_cp_fsdp, atol=self.tol, rtol=self.tol
+                mean_loss_cp_fsdp, loss, atol=self.tol, rtol=self.tol
             )
 
         # TODO: @goon - FSDP2 grad clipping is more involved; see torch-titan.

--- a/tests/mamba_cp/test_real_cp.py
+++ b/tests/mamba_cp/test_real_cp.py
@@ -1,0 +1,1607 @@
+from copy import deepcopy
+from typing import Optional
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from einops import rearrange
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import ShardingStrategy
+from torch.distributed.fsdp.wrap import ModuleWrapPolicy
+
+from dtest import DTest
+from mamba_ssm.models.config_mamba import MambaConfig
+from mamba_ssm.models.mixer_seq_simple import MambaLMHeadModel
+from mamba_ssm.modules.mamba2 import Mamba2
+from mamba_ssm.modules.mamba2_cp import (
+    CP_MAMBA_IMPLS,
+    MHACP,
+    Mamba2CP,
+    causal_passing_comms,
+    conv,
+    conv_cp,
+    identity_fwd_all_reduce_bwd,
+    in_proj_split,
+    seq_to_zigzag_comms,
+    zigzag_to_seq_comms,
+)
+from mamba_ssm.modules.mha import MHA
+from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+
+"""
+TODO: Parametrize the tests. Currently left unparametrized for easier debugging/dev workflow.
+"""
+
+
+def _test_model_model_cp_grads_close(
+    model: nn.Module,
+    model_cp: nn.Module,
+    tol: float = 1e-2,
+    all_reduce: bool = True,
+) -> None:
+    grads = {n: p.grad for n, p in model.named_parameters() if p.grad is not None}
+    grads_cp = {
+        n: deepcopy(p.grad)
+        for n, p in model_cp.named_parameters()
+        if p.grad is not None
+    }
+    if all_reduce:
+        for g_cp in grads_cp.values():
+            dist.all_reduce(g_cp)
+    dist.barrier()
+    assert set(grads) == set(grads_cp)
+    fails = {}
+    for n, g_cp in grads_cp.items():
+        g = grads[n]
+        try:
+            # NOTE: @goon - torch.testing.assert_close on the grads is an extremely strict metric,
+            # which is hard to pass, so just test the mean abs diff relative to the mean abs sum.
+            rel_diff = (g - g_cp).abs().mean() / (g + g_cp).abs().mean()
+            assert rel_diff < tol, f"{rel_diff =} not less than {tol=}"
+        except Exception as e:
+            fails[n] = e
+    if fails:
+        err_msg = []
+        for n, err in fails.items():
+            err_msg.append("\n***************")
+            err_msg.append(f"FAILED on parameter {n}")
+            err_msg.append(str(err))
+            err_msg.append("***************\n")
+        raise RuntimeError("\n".join(err_msg))
+
+
+class TestCausalPassingFn(DTest):
+    def test_fwd(self):
+        torch.manual_seed(42)
+        dim = 16
+        t_send = torch.randn(
+            self.world_size,
+            dim,
+            device=self.device,
+            dtype=torch.bfloat16,
+        )
+        mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        t_recv = causal_passing_comms(t_send[self.rank], mesh)
+        if self.rank == 0:
+            torch.testing.assert_close(t_recv, torch.zeros_like(t_recv))
+        else:
+            torch.testing.assert_close(t_recv, t_send[(self.rank - 1)])
+
+    def test_bwd(self):
+        torch.manual_seed(42)
+        dim = 16
+        t_send = torch.randn(
+            self.world_size,
+            dim,
+            device=self.device,
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        t_recv = causal_passing_comms(t_send[self.rank], mesh)
+        t_recv.pow(2).div(2).sum().backward()
+
+        if self.rank == self.world_size - 1:
+            assert t_send.grad is None
+        else:
+            grad = t_send.grad[self.rank]
+            torch.testing.assert_close(grad, t_send[self.rank])
+            other_idxs = torch.arange(self.world_size, device=self.device) != self.rank
+            zero_grads = t_send.grad[other_idxs]
+            torch.testing.assert_close(zero_grads, torch.zeros_like(zero_grads))
+
+
+class TestSeqToZigZagFn(DTest):
+    def test_fwd(self):
+        seq_dim = 1
+        dtype = torch.bfloat16
+        # Send the mini shard idx tensors around
+        t_send = torch.tensor(
+            [[2 * self.rank, 2 * self.rank + 1]],
+            device=self.device,
+            dtype=dtype,
+        )
+        mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        t_recv = seq_to_zigzag_comms(t_send, mesh, seq_dim)
+        t_expected = torch.tensor(
+            [[self.rank, 2 * self.world_size - self.rank - 1]],
+            device=self.device,
+            dtype=dtype,
+        )
+        torch.testing.assert_close(t_recv, t_expected)
+
+    def test_bwd(self):
+        seq_dim = 1
+        dtype = torch.bfloat16
+        t_send = torch.tensor(
+            [[2 * self.rank, 2 * self.rank + 1]],
+            device=self.device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+
+        mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        t_recv = seq_to_zigzag_comms(t_send, mesh, seq_dim)
+        t_recv.pow(2).div(2).sum().backward()
+
+        grad = t_send.grad
+        torch.testing.assert_close(grad, t_send)
+
+
+class TestZigZagToSeqFn(DTest):
+    def test_fwd(self):
+        seq_dim = 1
+        dtype = torch.bfloat16
+        # Send the mini shard idx tensors around
+        t_send = torch.tensor(
+            [[self.rank, 2 * self.world_size - self.rank - 1]],
+            device=self.device,
+            dtype=dtype,
+        )
+        mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        t_recv = zigzag_to_seq_comms(t_send, mesh, seq_dim)
+        t_expected = torch.tensor(
+            [[2 * self.rank, 2 * self.rank + 1]],
+            device=self.device,
+            dtype=dtype,
+        )
+        torch.testing.assert_close(t_recv, t_expected)
+
+    def test_bwd(self):
+        seq_dim = 1
+        dtype = torch.bfloat16
+        t_send = torch.tensor(
+            [[self.rank, 2 * self.world_size - self.rank - 1]],
+            device=self.device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+
+        mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        t_recv = seq_to_zigzag_comms(t_send, mesh, seq_dim)
+        t_recv.pow(2).div(2).sum().backward()
+
+        grad = t_send.grad
+        torch.testing.assert_close(grad, t_send)
+
+
+class TestZigZagToSeqInverse(DTest):
+    """
+    zigzag_to_seq_comms and seq_to_zigzag_comms should be inverses of each other.
+    """
+
+    def test_seq_then_zig(self) -> None:
+        seq_dim = 1
+        dtype = torch.bfloat16
+        # Send the mini shard idx tensors around
+        t_send = torch.tensor(
+            [[self.rank, 2 * self.world_size - self.rank - 1]],
+            device=self.device,
+            dtype=dtype,
+        )
+        mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        # Send and send again
+        t_recv = seq_to_zigzag_comms(t_send, mesh, seq_dim)
+        t_recv = zigzag_to_seq_comms(t_recv, mesh, seq_dim)
+        torch.testing.assert_close(t_recv, t_send)
+
+    def test_zig_then_seq(self) -> None:
+        seq_dim = 1
+        dtype = torch.bfloat16
+        # Send the mini shard idx tensors around
+        t_send = torch.tensor(
+            [[self.rank, 2 * self.world_size - self.rank - 1]],
+            device=self.device,
+            dtype=dtype,
+        )
+        mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        # Send and send again
+        t_recv = zigzag_to_seq_comms(t_send, mesh, seq_dim)
+        t_recv = seq_to_zigzag_comms(t_recv, mesh, seq_dim)
+        torch.testing.assert_close(t_recv, t_send)
+
+
+class TestIdentityFwdAllGatherBwdFn(DTest):
+    def test_fwd(self):
+        dim = 16
+        torch.manual_seed(42)
+        weight = torch.randn(
+            dim,
+            device=self.device,
+            dtype=torch.bfloat16,
+        )
+        weight_copy = deepcopy(weight)
+
+        weight = nn.Parameter(weight)
+        mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        weight_copy = nn.Parameter(weight_copy)
+
+        inputs = torch.randn(
+            self.world_size,
+            dim,
+            device=self.device,
+            dtype=torch.bfloat16,
+        )
+        inputs_shard = inputs.tensor_split(self.world_size, 0)[self.rank]
+
+        output = inputs * weight
+        output_shard = inputs_shard * identity_fwd_all_reduce_bwd(weight_copy, mesh)
+
+        all_gathered_output_shards = torch.empty_like(inputs)
+        dist.all_gather_into_tensor(
+            all_gathered_output_shards, output_shard, group=mesh.get_group()
+        )
+        out = [torch.empty_like(output_shard) for _ in range(self.world_size)]
+        dist.all_gather(out, output_shard, group=mesh.get_group())
+
+        torch.testing.assert_close(all_gathered_output_shards, output)
+
+    def test_bwd(self):
+        dim = 16
+        torch.manual_seed(42)
+        weight = torch.randn(
+            dim,
+            device=self.device,
+            dtype=torch.bfloat16,
+        )
+        weight_copy = deepcopy(weight)
+
+        weight = nn.Parameter(weight)
+        mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        weight_copy = nn.Parameter(weight_copy)
+
+        inputs = torch.randn(
+            self.world_size,
+            dim,
+            device=self.device,
+            dtype=torch.bfloat16,
+        )
+        inputs_shard = inputs.tensor_split(self.world_size, 0)[self.rank]
+
+        (inputs * weight).sum().backward()
+        (inputs_shard * identity_fwd_all_reduce_bwd(weight_copy, mesh)).sum().backward()
+
+        torch.testing.assert_close(weight.grad, weight_copy.grad)
+
+
+class _DTestModelBase(DTest):
+    batch_size = 2
+    chunk_size = 4
+    d_model = 256
+    d_state = 128
+    ngroups = 1
+    expand = 2
+    d_conv = 4
+    d_inner = expand * d_model
+    d_ssm = d_inner
+    embed_dim = d_model
+    head_dim = 64
+    num_heads = d_model // head_dim
+    dtype = torch.float32
+    ssm_cfg = {"layer": "Mamba2"}
+    vocab_size = 1024
+    n_layer = 2
+    attn_layer_idx = [n_layer - 1]
+    attn_cfg = {
+        "causal": True,
+        "d_conv": 0,
+        "head_dim": head_dim,
+        "num_heads": num_heads,
+        "out_proj_bias": False,
+        "qkv_proj_bias": False,
+        "rotary_emb_dim": head_dim // 2,
+    }
+    cfg = MambaConfig(
+        d_model=d_model,
+        n_layer=n_layer,
+        vocab_size=vocab_size,
+        ssm_cfg=ssm_cfg,
+        attn_layer_idx=attn_layer_idx,
+        attn_cfg=attn_cfg,
+        tie_embeddings=False,
+    )
+
+    @property
+    def seq_len(self) -> int:
+        return 4 * self.world_size * self.chunk_size
+
+    @property
+    def n_chunks(self) -> int:
+        return self.seq_len // self.chunk_size
+
+    @property
+    def factory_kwargs(self):
+        return {"dtype": self.dtype, "device": self.device}
+
+    def get_mamba2(self, seed: int = 42) -> Mamba2:
+        torch.manual_seed(seed)
+        return Mamba2(
+            d_model=self.d_model,
+            d_state=self.d_state,
+            chunk_size=self.chunk_size,
+            **self.factory_kwargs,
+        )
+
+    def get_mamba2_cp(
+        self,
+        cp_mesh: dist.device_mesh.DeviceMesh,
+        seed: int = 42,
+        cp_mamba_impl: str = "allgather",
+    ) -> Mamba2:
+        torch.manual_seed(seed)
+        return Mamba2CP(
+            cp_mesh=cp_mesh,
+            d_model=self.d_model,
+            d_state=self.d_state,
+            chunk_size=self.chunk_size,
+            cp_mamba_impl=cp_mamba_impl,
+            **self.factory_kwargs,
+        )
+
+    def get_mha(self, seed: int = 42, dtype: torch.dtype = torch.bfloat16) -> MHA:
+        torch.manual_seed(seed)
+        return MHA(
+            embed_dim=self.embed_dim,
+            num_heads=self.num_heads,
+            causal=True,
+            device=self.device,
+            dtype=dtype,
+        )
+
+    def get_mha_cp(
+        self,
+        cp_mesh: dist.device_mesh.DeviceMesh,
+        seed: int = 42,
+        dtype: torch.dtype = torch.bfloat16,
+        cp_attn_impl: str = "zigzag",
+    ) -> MHA:
+        torch.manual_seed(seed)
+        return MHACP(
+            cp_mesh=cp_mesh,
+            embed_dim=self.embed_dim,
+            num_heads=self.num_heads,
+            causal=True,
+            device=self.device,
+            dtype=dtype,
+            cp_attn_impl=cp_attn_impl,
+        )
+
+    def get_model(
+        self, seed: int = 42, dtype: torch.dtype = torch.bfloat16
+    ) -> MambaLMHeadModel:
+        torch.manual_seed(seed)
+        return MambaLMHeadModel(config=self.cfg, device=self.device, dtype=dtype)
+
+    def get_model_cp(
+        self,
+        cp_mesh: dist.device_mesh.DeviceMesh,
+        cp_mamba_impl: str,
+        cp_attn_impl: str,
+        seed: int = 42,
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> MambaLMHeadModel:
+        torch.manual_seed(seed)
+        return MambaLMHeadModel(
+            config=self.cfg,
+            cp_mesh=cp_mesh,
+            cp_mamba_impl=cp_mamba_impl,
+            cp_attn_impl=cp_attn_impl,
+            device=self.device,
+            dtype=dtype,
+        )
+
+    def get_input_toks(
+        self,
+        seed: int = 42,
+    ) -> torch.Tensor:
+        torch.manual_seed(seed)
+        return torch.randint(
+            self.vocab_size,
+            size=(
+                self.batch_size,
+                self.seq_len,
+            ),
+            device=self.device,
+        )
+
+    def get_inputs(
+        self,
+        requires_grad: bool = False,
+        seed: int = 42,
+        dtype: Optional[torch.dtype] = None,
+        batch_size: Optional[int] = None,
+    ) -> torch.Tensor:
+        torch.manual_seed(seed)
+        if batch_size is None:
+            batch_size = self.batch_size
+        return torch.randn(
+            batch_size,
+            self.seq_len,
+            self.d_model,
+            device=self.device,
+            dtype=dtype or self.dtype,
+            requires_grad=requires_grad,
+        )
+
+    def get_cp_shard(
+        self,
+        tensor: torch.Tensor,
+        n_shards: Optional[int] = None,
+        rank: Optional[int] = None,
+    ) -> torch.Tensor:
+        if n_shards is None:
+            n_shards = self.world_size
+        if rank is None:
+            rank = self.rank
+
+        shard = rearrange(tensor, "b (r l) ... -> b r l ...", r=n_shards)[:, rank]
+        return shard
+
+    def get_xBC(self, requires_grad: bool = False) -> torch.Tensor:
+        return torch.randn(
+            self.batch_size,
+            self.seq_len,
+            self.d_ssm + 2 * self.ngroups * self.d_state,
+            **self.factory_kwargs,
+            requires_grad=requires_grad,
+        )
+
+    def get_scan_kwargs(self, inputs, mamba2):
+        """
+        Get all kwargs for the scan.
+        """
+        A = -torch.exp(mamba2.A_log.float())  # (nheads) or (d_inner, d_state)
+        _, _, z, xBC, dt = in_proj_split(inputs, mamba2)
+        x, B, C = torch.split(
+            xBC,
+            [
+                mamba2.d_ssm,
+                mamba2.ngroups * mamba2.d_state,
+                mamba2.ngroups * mamba2.d_state,
+            ],
+            dim=-1,
+        )
+
+        scan_kwargs = dict(
+            A=A,
+            chunk_size=mamba2.chunk_size,
+            D=rearrange(mamba2.D, "(h p) -> h p", p=mamba2.headdim)
+            if mamba2.D_has_hdim
+            else mamba2.D,
+            dt_bias=mamba2.dt_bias,
+            dt_softplus=True,
+            x=rearrange(x, "b l (h p) -> b l h p", p=mamba2.headdim),
+            dt=dt,
+            B=rearrange(B, "b l (g n) -> b l g n", g=mamba2.ngroups),
+            C=rearrange(C, "b l (g n) -> b l g n", g=mamba2.ngroups),
+            z=rearrange(z, "b l (h p) -> b l h p", p=mamba2.headdim)
+            if not mamba2.rmsnorm
+            else None,
+        )
+        return scan_kwargs
+
+
+class TestConvCP(_DTestModelBase):
+    def test_fwd(self):
+        torch.manual_seed(42)
+        mamba2 = self.get_mamba2()
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        xBC = self.get_xBC()
+
+        xBC_cp = self.get_cp_shard(xBC)
+
+        outputs = conv(xBC, mamba2)
+        outputs_cp = conv_cp(xBC_cp, mamba2, cp_mesh)
+        torch.testing.assert_close(
+            outputs_cp, outputs.tensor_split(self.world_size, dim=1)[self.rank]
+        )
+
+    def test_bwd(self):
+        torch.manual_seed(42)
+        mamba2 = self.get_mamba2()
+        mamba2_cp = deepcopy(mamba2)
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+
+        xBC = self.get_xBC(requires_grad=True)
+        xBC_copy = deepcopy(xBC)
+
+        xBC_cp = self.get_cp_shard(xBC_copy)
+        outputs = conv(xBC, mamba2)
+        outputs.sum().backward()
+        outputs_cp = conv_cp(xBC_cp, mamba2_cp, cp_mesh)
+        outputs_cp.sum().backward()
+
+        xBC_grad_shard = self.get_cp_shard(xBC.grad)
+        xBC_cp_grad_shard = self.get_cp_shard(xBC_copy.grad)
+        tol = None if self.dtype == torch.float32 else 1e-2
+        torch.testing.assert_close(
+            xBC_grad_shard, xBC_cp_grad_shard, atol=tol, rtol=tol
+        )
+
+
+class TestSerialScanCP(_DTestModelBase):
+    cp_mamba_impl = "serial"
+
+    def test_fwd(self):
+        torch.manual_seed(42)
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        inputs = self.get_inputs()
+        mamba2 = self.get_mamba2()
+
+        # The correct global outputs:
+        kwargs = self.get_scan_kwargs(inputs, mamba2)
+        outputs = mamba_chunk_scan_combined(**kwargs)
+
+        # And the CP output:
+        inputs_cp_shard = self.get_cp_shard(inputs)
+        kwargs_cp = self.get_scan_kwargs(inputs_cp_shard, mamba2)
+        outputs_cp = CP_MAMBA_IMPLS[self.cp_mamba_impl](cp_mesh=cp_mesh, **kwargs_cp)
+
+        # All-gather and verify correctness
+        outputs_cp_all_gathered = torch.empty(
+            self.world_size,
+            *outputs_cp.shape,
+            dtype=outputs_cp.dtype,
+            device=outputs_cp.device,
+        )
+        dist.all_gather_into_tensor(
+            outputs_cp_all_gathered, outputs_cp, cp_mesh.get_group()
+        )
+        outputs_cp_all_gathered = rearrange(
+            outputs_cp_all_gathered, "r b l ... -> b (r l) ..."
+        )
+        tol = 1e-3
+        torch.testing.assert_close(outputs, outputs_cp_all_gathered, atol=tol, rtol=tol)
+
+    def test_bwd(self):
+        torch.manual_seed(42)
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+
+        inputs = self.get_inputs(requires_grad=True)
+        mamba2 = self.get_mamba2()
+
+        inputs_copy = deepcopy(inputs)
+        inputs_cp = self.get_cp_shard(inputs_copy)
+        mamba2_cp = deepcopy(mamba2)
+
+        # Backward on the correct global result
+        kwargs = self.get_scan_kwargs(inputs, mamba2)
+        outputs = mamba_chunk_scan_combined(**kwargs)
+        outputs.sum().backward()
+
+        # And on the CP output:
+        kwargs_cp = self.get_scan_kwargs(inputs_cp, mamba2_cp)
+        outputs_cp = CP_MAMBA_IMPLS[self.cp_mamba_impl](cp_mesh=cp_mesh, **kwargs_cp)
+        outputs_cp.sum().backward()
+
+        # Rearrange grads to compare proper slices
+        inputs_grad_shard = self.get_cp_shard(inputs.grad)
+        inputs_cp_grad_shard = self.get_cp_shard(inputs_copy.grad)
+
+        tol = 1e-2
+        torch.testing.assert_close(
+            inputs_grad_shard, inputs_cp_grad_shard, atol=tol, rtol=tol
+        )
+
+        # Parameter grads should match after all-reducing.
+        _test_model_model_cp_grads_close(mamba2, mamba2_cp)
+
+
+class TestAllGatherScanCP(_DTestModelBase):
+    cp_mamba_impl = "allgather"
+
+    def test_fwd(self):
+        torch.manual_seed(42)
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        inputs = self.get_inputs()
+        mamba2 = self.get_mamba2()
+
+        # The correct global outputs:
+        kwargs = self.get_scan_kwargs(inputs, mamba2)
+        outputs = mamba_chunk_scan_combined(**kwargs)
+
+        # And the CP output:
+        inputs_cp_shard = self.get_cp_shard(inputs)
+        kwargs_cp = self.get_scan_kwargs(inputs_cp_shard, mamba2)
+        outputs_cp = CP_MAMBA_IMPLS[self.cp_mamba_impl](cp_mesh=cp_mesh, **kwargs_cp)
+
+        # All-gather and verify correctness
+        outputs_cp_all_gathered = torch.empty(
+            self.world_size,
+            *outputs_cp.shape,
+            dtype=outputs_cp.dtype,
+            device=outputs_cp.device,
+        )
+        dist.all_gather_into_tensor(
+            outputs_cp_all_gathered, outputs_cp, cp_mesh.get_group()
+        )
+        outputs_cp_all_gathered = rearrange(
+            outputs_cp_all_gathered, "r b l ... -> b (r l) ..."
+        )
+        tol = 1e-3
+        torch.testing.assert_close(outputs, outputs_cp_all_gathered, atol=tol, rtol=tol)
+
+    def test_bwd(self):
+        torch.manual_seed(42)
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+
+        inputs = self.get_inputs(requires_grad=True)
+        mamba2 = self.get_mamba2()
+
+        inputs_copy = deepcopy(inputs)
+        inputs_cp = self.get_cp_shard(inputs_copy)
+        mamba2_cp = deepcopy(mamba2)
+
+        # Backward on the correct global result
+        kwargs = self.get_scan_kwargs(inputs, mamba2)
+        outputs = mamba_chunk_scan_combined(**kwargs)
+        outputs.sum().backward()
+
+        # And on the CP output:
+        kwargs_cp = self.get_scan_kwargs(inputs_cp, mamba2_cp)
+        outputs_cp = CP_MAMBA_IMPLS[self.cp_mamba_impl](cp_mesh=cp_mesh, **kwargs_cp)
+        outputs_cp.sum().backward()
+
+        # Rearrange grads to compare proper slices
+        inputs_grad_shard = self.get_cp_shard(inputs.grad)
+        inputs_cp_grad_shard = self.get_cp_shard(inputs_copy.grad)
+
+        tol = 1e-2
+        torch.testing.assert_close(
+            inputs_grad_shard, inputs_cp_grad_shard, atol=tol, rtol=tol
+        )
+
+        # Parameter grads should match after all-reducing.
+        _test_model_model_cp_grads_close(mamba2, mamba2_cp)
+
+
+class TestMamba2CPSerial(_DTestModelBase):
+    cp_mamba_impl = "serial"
+
+    def test_fwd(self):
+        torch.manual_seed(42)
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        mamba2 = self.get_mamba2()
+        mamba2_cp = self.get_mamba2_cp(
+            cp_mesh=cp_mesh, cp_mamba_impl=self.cp_mamba_impl
+        )
+
+        inputs = self.get_inputs()
+        inputs_cp = self.get_cp_shard(inputs)
+
+        outputs = mamba2(inputs)
+        outputs_cp = mamba2_cp(inputs_cp)
+
+        outputs_shard = self.get_cp_shard(outputs)
+        torch.testing.assert_close(outputs_cp, outputs_shard)
+
+    def test_bwd(self):
+        torch.manual_seed(42)
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        mamba2 = self.get_mamba2()
+        mamba2_cp = self.get_mamba2_cp(
+            cp_mesh=cp_mesh, cp_mamba_impl=self.cp_mamba_impl
+        )
+
+        inputs = self.get_inputs(requires_grad=True)
+        inputs_copy = deepcopy(inputs)
+        inputs_cp = self.get_cp_shard(inputs_copy)
+
+        outputs = mamba2(inputs)
+        outputs.sum().backward()
+        outputs_cp = mamba2_cp(inputs_cp)
+        outputs_cp.sum().backward()
+
+        inputs_grad_shard = self.get_cp_shard(inputs.grad)
+        inputs_cp_grad_shard = self.get_cp_shard(inputs_copy.grad)
+        torch.testing.assert_close(inputs_grad_shard, inputs_cp_grad_shard)
+
+        # Parameter grads should match after all-reducing.
+        _test_model_model_cp_grads_close(mamba2, mamba2_cp)
+
+
+class TestMamba2CPAllGather(_DTestModelBase):
+    cp_mamba_impl = "allgather"
+
+    def test_fwd(self):
+        torch.manual_seed(42)
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        mamba2 = self.get_mamba2()
+        mamba2_cp = self.get_mamba2_cp(
+            cp_mesh=cp_mesh, cp_mamba_impl=self.cp_mamba_impl
+        )
+
+        inputs = self.get_inputs()
+        inputs_cp = self.get_cp_shard(inputs)
+
+        outputs = mamba2(inputs)
+        outputs_cp = mamba2_cp(inputs_cp)
+
+        outputs_shard = self.get_cp_shard(outputs)
+        torch.testing.assert_close(outputs_cp, outputs_shard)
+
+    def test_bwd(self):
+        torch.manual_seed(42)
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        mamba2 = self.get_mamba2()
+        mamba2_cp = self.get_mamba2_cp(
+            cp_mesh=cp_mesh, cp_mamba_impl=self.cp_mamba_impl
+        )
+
+        inputs = self.get_inputs(requires_grad=True)
+        inputs_copy = deepcopy(inputs)
+        inputs_cp = self.get_cp_shard(inputs_copy)
+
+        outputs = mamba2(inputs)
+        outputs.sum().backward()
+        outputs_cp = mamba2_cp(inputs_cp)
+        outputs_cp.sum().backward()
+
+        inputs_grad_shard = self.get_cp_shard(inputs.grad)
+        inputs_cp_grad_shard = self.get_cp_shard(inputs_copy.grad)
+        torch.testing.assert_close(inputs_grad_shard, inputs_cp_grad_shard)
+
+        # Parameter grads should match after all-reducing.
+        _test_model_model_cp_grads_close(mamba2, mamba2_cp)
+
+
+class TestMHACPRing(_DTestModelBase):
+    cp_attn_impl = "ring"
+
+    def test_fwd(self):
+        torch.manual_seed(42)
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        mha = self.get_mha()
+        mha_cp = self.get_mha_cp(cp_mesh=cp_mesh, cp_attn_impl=self.cp_attn_impl)
+
+        # Requires bfloat16
+        inputs = self.get_inputs(dtype=torch.bfloat16)
+        inputs_cp = self.get_cp_shard(inputs)
+
+        outputs = mha(inputs)
+        outputs_cp = mha_cp(inputs_cp)
+
+        outputs_shard = self.get_cp_shard(outputs)
+        tol = 1e-2
+        torch.testing.assert_close(outputs_cp, outputs_shard, atol=tol, rtol=tol)
+
+    def test_bwd(self):
+        torch.manual_seed(42)
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        mha = self.get_mha()
+        mha_cp = self.get_mha_cp(cp_mesh=cp_mesh, cp_attn_impl=self.cp_attn_impl)
+
+        # Requires bfloat16
+        inputs = self.get_inputs(requires_grad=True, dtype=torch.bfloat16)
+        inputs_copy = deepcopy(inputs)
+        inputs_cp = self.get_cp_shard(inputs_copy)
+
+        outputs = mha(inputs)
+        outputs.sum().backward()
+        outputs_cp = mha_cp(inputs_cp)
+        outputs_cp.sum().backward()
+
+        inputs_grad_shard = self.get_cp_shard(inputs.grad)
+        inputs_cp_grad_shard = self.get_cp_shard(inputs_copy.grad)
+        tol = 1e-2
+        dist.barrier()
+        torch.testing.assert_close(
+            inputs_grad_shard, inputs_cp_grad_shard, atol=tol, rtol=tol
+        )
+
+        # Parameter grads should match after all-reducing.
+        # Needs a high tol to pass?
+        _test_model_model_cp_grads_close(mha, mha_cp)
+
+
+class TestMHACPZigZag(_DTestModelBase):
+    cp_attn_impl = "zigzag"
+
+    def test_fwd(self):
+        torch.manual_seed(42)
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        mha = self.get_mha()
+        mha_cp = self.get_mha_cp(cp_mesh=cp_mesh, cp_attn_impl=self.cp_attn_impl)
+
+        # Requires bfloat16
+        inputs = self.get_inputs(dtype=torch.bfloat16)
+        inputs_cp = self.get_cp_shard(inputs)
+
+        outputs = mha(inputs)
+        outputs_cp = mha_cp(inputs_cp)
+
+        outputs_shard = self.get_cp_shard(outputs)
+        tol = 1e-2
+        torch.testing.assert_close(outputs_cp, outputs_shard, atol=tol, rtol=tol)
+
+    def test_bwd(self):
+        torch.manual_seed(42)
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        mha = self.get_mha()
+        mha_cp = self.get_mha_cp(cp_mesh=cp_mesh, cp_attn_impl=self.cp_attn_impl)
+
+        # Requires bfloat16
+        inputs = self.get_inputs(requires_grad=True, dtype=torch.bfloat16)
+        inputs_copy = deepcopy(inputs)
+        inputs_cp = self.get_cp_shard(inputs_copy)
+
+        outputs = mha(inputs)
+        outputs.sum().backward()
+        outputs_cp = mha_cp(inputs_cp)
+        outputs_cp.sum().backward()
+
+        inputs_grad_shard = self.get_cp_shard(inputs.grad)
+        inputs_cp_grad_shard = self.get_cp_shard(inputs_copy.grad)
+        tol = 1e-2
+        dist.barrier()
+        torch.testing.assert_close(
+            inputs_grad_shard, inputs_cp_grad_shard, atol=tol, rtol=tol
+        )
+
+        # Parameter grads should match after all-reducing.
+        # Needs a high tol to pass?
+        _test_model_model_cp_grads_close(mha, mha_cp)
+
+
+class TestFSDP1MambaCPSerial(_DTestModelBase):
+    cp_mamba_impl = "serial"
+
+    def test_fwd(self):
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        model = nn.Sequential(*[self.get_mamba2() for _ in range(3)])
+        model_cp = nn.Sequential(
+            *[
+                self.get_mamba2_cp(cp_mesh=cp_mesh, cp_mamba_impl=self.cp_mamba_impl)
+                for _ in range(3)
+            ]
+        )
+        model_cp_fsdp = FSDP(
+            model_cp,
+            process_group=cp_mesh.get_group(),
+            auto_wrap_policy=ModuleWrapPolicy([Mamba2CP]),
+            sharding_strategy=ShardingStrategy.FULL_SHARD,
+            use_orig_params=True,
+            device_id=self.device,
+        )
+
+        inputs = self.get_inputs()
+        inputs_cp = self.get_cp_shard(inputs)
+
+        outputs = model(inputs)
+        outputs_cp_fsdp = model_cp_fsdp(inputs_cp)
+
+        outputs_shard = self.get_cp_shard(outputs)
+        torch.testing.assert_close(outputs_cp_fsdp, outputs_shard)
+
+    def test_bwd(self):
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        model = nn.Sequential(*[self.get_mamba2() for _ in range(3)])
+        model_cp = nn.Sequential(
+            *[
+                self.get_mamba2_cp(cp_mesh=cp_mesh, cp_mamba_impl=self.cp_mamba_impl)
+                for _ in range(3)
+            ]
+        )
+        model_cp_fsdp = FSDP(
+            model_cp,
+            process_group=cp_mesh.get_group(),
+            auto_wrap_policy=ModuleWrapPolicy([Mamba2CP]),
+            sharding_strategy=ShardingStrategy.FULL_SHARD,
+            use_orig_params=True,
+            device_id=self.device,
+        )
+        # NOTE: for grads to match the non-FSDP case, some scaling need to be performed. Options:
+        # 1) Change FSDP._gradient_predivide_factor from the DP world size to 1.0
+        # 2) Scale up the loss by a factor of the DP world size
+        # The latter is also automatically handled if the loss function scales by the world size,
+        # as in the case of a mean or default cross_entropy loss with equals tokens per rank, but it
+        # also makes the outputs mismatch, while 1) keeps the FSDP and non-FSDP outputs the same.
+        #
+        # We just use the mean for the loss below.
+
+        inputs = self.get_inputs(requires_grad=True)
+        inputs_copy = deepcopy(inputs)
+        inputs_cp_fsdp = self.get_cp_shard(inputs_copy)
+
+        outputs = model(inputs)
+        outputs.mean().backward()
+        outputs_cp_fsdp = model_cp_fsdp(inputs_cp_fsdp)
+        outputs_cp_fsdp.mean().backward()
+
+        with FSDP.summon_full_params(model_cp_fsdp, with_grads=True):
+            dist.barrier()
+            _test_model_model_cp_grads_close(model, model_cp_fsdp, all_reduce=False)
+
+
+class TestFSDP1MambaCPAllGather(_DTestModelBase):
+    cp_mamba_impl = "allgather"
+
+    def test_fwd(self):
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        model = nn.Sequential(*[self.get_mamba2() for _ in range(3)])
+        model_cp = nn.Sequential(
+            *[
+                self.get_mamba2_cp(cp_mesh=cp_mesh, cp_mamba_impl=self.cp_mamba_impl)
+                for _ in range(3)
+            ]
+        )
+        model_cp_fsdp = FSDP(
+            model_cp,
+            process_group=cp_mesh.get_group(),
+            auto_wrap_policy=ModuleWrapPolicy([Mamba2CP]),
+            sharding_strategy=ShardingStrategy.FULL_SHARD,
+            use_orig_params=True,
+            device_id=self.device,
+        )
+
+        inputs = self.get_inputs()
+        inputs_cp = self.get_cp_shard(inputs)
+
+        outputs = model(inputs)
+        outputs_cp_fsdp = model_cp_fsdp(inputs_cp)
+
+        outputs_shard = self.get_cp_shard(outputs)
+        torch.testing.assert_close(outputs_cp_fsdp, outputs_shard)
+
+    def test_bwd(self):
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        model = nn.Sequential(*[self.get_mamba2() for _ in range(3)])
+        model_cp = nn.Sequential(
+            *[
+                self.get_mamba2_cp(cp_mesh=cp_mesh, cp_mamba_impl=self.cp_mamba_impl)
+                for _ in range(3)
+            ]
+        )
+        model_cp_fsdp = FSDP(
+            model_cp,
+            process_group=cp_mesh.get_group(),
+            auto_wrap_policy=ModuleWrapPolicy([Mamba2CP]),
+            sharding_strategy=ShardingStrategy.FULL_SHARD,
+            use_orig_params=True,
+            device_id=self.device,
+        )
+        # NOTE: for grads to match the non-FSDP case, some scaling need to be performed. Options:
+        # 1) Change FSDP._gradient_predivide_factor from the DP world size to 1.0
+        # 2) Scale up the loss by a factor of the DP world size
+        # The latter is also automatically handled if the loss function scales by the world size,
+        # as in the case of a mean or default cross_entropy loss with equals tokens per rank, but it
+        # also makes the outputs mismatch, while 1) keeps the FSDP and non-FSDP outputs the same.
+        #
+        # We just use the mean for the loss below.
+
+        inputs = self.get_inputs(requires_grad=True)
+        inputs_copy = deepcopy(inputs)
+        inputs_cp_fsdp = self.get_cp_shard(inputs_copy)
+
+        outputs = model(inputs)
+        outputs.mean().backward()
+        outputs_cp_fsdp = model_cp_fsdp(inputs_cp_fsdp)
+        outputs_cp_fsdp.mean().backward()
+
+        with FSDP.summon_full_params(model_cp_fsdp, with_grads=True):
+            dist.barrier()
+            _test_model_model_cp_grads_close(model, model_cp_fsdp, all_reduce=False)
+
+
+class TestFSDP1MHACPRing(_DTestModelBase):
+    cp_attn_impl = "ring"
+
+    def test_fwd(self):
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        model = nn.Sequential(*[self.get_mha() for _ in range(3)])
+        model_cp = nn.Sequential(
+            *[
+                self.get_mha_cp(cp_mesh=cp_mesh, cp_attn_impl=self.cp_attn_impl)
+                for _ in range(3)
+            ]
+        )
+        model_cp_fsdp = FSDP(
+            model_cp,
+            process_group=cp_mesh.get_group(),
+            auto_wrap_policy=ModuleWrapPolicy([MHACP]),
+            sharding_strategy=ShardingStrategy.FULL_SHARD,
+            use_orig_params=True,
+            device_id=self.device,
+        )
+
+        inputs = self.get_inputs(dtype=torch.bfloat16)
+        inputs_cp = self.get_cp_shard(inputs)
+
+        outputs = model(inputs)
+        outputs_cp_fsdp = model_cp_fsdp(inputs_cp)
+
+        outputs_shard = self.get_cp_shard(outputs)
+        tol = 1e-3
+        torch.testing.assert_close(outputs_cp_fsdp, outputs_shard, atol=tol, rtol=tol)
+
+    def test_bwd(self):
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        model = nn.Sequential(*[self.get_mha() for _ in range(3)])
+        model_cp = nn.Sequential(
+            *[
+                self.get_mha_cp(cp_mesh=cp_mesh, cp_attn_impl=self.cp_attn_impl)
+                for _ in range(3)
+            ]
+        )
+        model_cp_fsdp = FSDP(
+            model_cp,
+            process_group=cp_mesh.get_group(),
+            auto_wrap_policy=ModuleWrapPolicy([MHACP]),
+            sharding_strategy=ShardingStrategy.FULL_SHARD,
+            use_orig_params=True,
+            device_id=self.device,
+        )
+        # NOTE: for grads to match the non-FSDP case, some scaling need to be performed. Options:
+        # 1) Change FSDP._gradient_predivide_factor from the DP world size to 1.0
+        # 2) Scale up the loss by a factor of the DP world size
+        # The latter is also automatically handled if the loss function scales by the world size,
+        # as in the case of a mean or default cross_entropy loss with equals tokens per rank, but it
+        # also makes the outputs mismatch, while 1) keeps the FSDP and non-FSDP outputs the same.
+        #
+        # We just use the mean for the loss below.
+
+        inputs = self.get_inputs(requires_grad=True, dtype=torch.bfloat16)
+        inputs_copy = deepcopy(inputs)
+        inputs_cp_fsdp = self.get_cp_shard(inputs_copy)
+
+        outputs = model(inputs)
+        outputs.mean().backward()
+        outputs_cp_fsdp = model_cp_fsdp(inputs_cp_fsdp)
+        outputs_cp_fsdp.mean().backward()
+
+        with FSDP.summon_full_params(model_cp_fsdp, with_grads=True):
+            dist.barrier()
+            _test_model_model_cp_grads_close(model, model_cp_fsdp, all_reduce=False)
+
+
+class TestFSDP1MHACPZigZag(_DTestModelBase):
+    cp_attn_impl = "zigzag"
+
+    def test_fwd(self):
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        model = nn.Sequential(*[self.get_mha() for _ in range(3)])
+        model_cp = nn.Sequential(
+            *[
+                self.get_mha_cp(cp_mesh=cp_mesh, cp_attn_impl=self.cp_attn_impl)
+                for _ in range(3)
+            ]
+        )
+        model_cp_fsdp = FSDP(
+            model_cp,
+            process_group=cp_mesh.get_group(),
+            auto_wrap_policy=ModuleWrapPolicy([MHACP]),
+            sharding_strategy=ShardingStrategy.FULL_SHARD,
+            use_orig_params=True,
+            device_id=self.device,
+        )
+
+        inputs = self.get_inputs(dtype=torch.bfloat16)
+        inputs_cp = self.get_cp_shard(inputs)
+
+        outputs = model(inputs)
+        outputs_cp_fsdp = model_cp_fsdp(inputs_cp)
+
+        outputs_shard = self.get_cp_shard(outputs)
+        tol = 1e-3
+        torch.testing.assert_close(outputs_cp_fsdp, outputs_shard, atol=tol, rtol=tol)
+
+    def test_bwd(self):
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        model = nn.Sequential(*[self.get_mha() for _ in range(3)])
+        model_cp = nn.Sequential(
+            *[
+                self.get_mha_cp(cp_mesh=cp_mesh, cp_attn_impl=self.cp_attn_impl)
+                for _ in range(3)
+            ]
+        )
+        model_cp_fsdp = FSDP(
+            model_cp,
+            process_group=cp_mesh.get_group(),
+            auto_wrap_policy=ModuleWrapPolicy([MHACP]),
+            sharding_strategy=ShardingStrategy.FULL_SHARD,
+            use_orig_params=True,
+            device_id=self.device,
+        )
+        # NOTE: for grads to match the non-FSDP case, some scaling need to be performed. Options:
+        # 1) Change FSDP._gradient_predivide_factor from the DP world size to 1.0
+        # 2) Scale up the loss by a factor of the DP world size
+        # The latter is also automatically handled if the loss function scales by the world size,
+        # as in the case of a mean or default cross_entropy loss with equals tokens per rank, but it
+        # also makes the outputs mismatch, while 1) keeps the FSDP and non-FSDP outputs the same.
+        #
+        # We just use the mean for the loss below.
+
+        inputs = self.get_inputs(requires_grad=True, dtype=torch.bfloat16)
+        inputs_copy = deepcopy(inputs)
+        inputs_cp_fsdp = self.get_cp_shard(inputs_copy)
+
+        outputs = model(inputs)
+        outputs.mean().backward()
+        outputs_cp_fsdp = model_cp_fsdp(inputs_cp_fsdp)
+        outputs_cp_fsdp.mean().backward()
+
+        with FSDP.summon_full_params(model_cp_fsdp, with_grads=True):
+            dist.barrier()
+            _test_model_model_cp_grads_close(model, model_cp_fsdp, all_reduce=False)
+
+
+class TestHSDP1MambaCPAllGather(_DTestModelBase):
+    """
+    Test HSDP + CP for MambaCP where the HSDP and CP dims cover the same subgroups
+    """
+
+    cp_mamba_impl = "allgather"
+
+    @pytest.mark.world_size(4)
+    def test_fwd(self):
+        mesh = dist.device_mesh.init_device_mesh(
+            "cuda", (2, 2), mesh_dim_names=("inter_node", "intra_node")
+        )
+        cp_mesh = mesh["intra_node"]
+        model = nn.Sequential(*[self.get_mamba2() for _ in range(3)])
+        model_cp = nn.Sequential(
+            *[
+                self.get_mamba2_cp(cp_mesh=cp_mesh, cp_mamba_impl=self.cp_mamba_impl)
+                for _ in range(3)
+            ]
+        )
+        model_cp_hsdp = FSDP(
+            model_cp,
+            device_mesh=mesh,
+            auto_wrap_policy=ModuleWrapPolicy([Mamba2CP]),
+            sharding_strategy=ShardingStrategy.FULL_SHARD,
+            use_orig_params=True,
+            device_id=self.device,
+        )
+        # Different CP groups get different inputs
+        inputs = self.get_inputs(seed=42 + mesh["inter_node"].get_local_rank())
+        inputs_cp = self.get_cp_shard(
+            inputs, n_shards=cp_mesh.size(), rank=cp_mesh.get_local_rank()
+        )
+
+        outputs = model(inputs)
+        outputs_cp_hsdp = model_cp_hsdp(inputs_cp)
+
+        outputs_shard = self.get_cp_shard(
+            outputs, n_shards=cp_mesh.size(), rank=cp_mesh.get_local_rank()
+        )
+        torch.testing.assert_close(outputs_cp_hsdp, outputs_shard)
+
+    @pytest.mark.world_size(4)
+    def test_bwd(self):
+        mesh = dist.device_mesh.init_device_mesh(
+            "cuda", (2, 2), mesh_dim_names=("inter_node", "intra_node")
+        )
+        cp_mesh = mesh["intra_node"]
+        model = nn.Sequential(*[self.get_mamba2() for _ in range(3)])
+        model_cp = nn.Sequential(
+            *[
+                self.get_mamba2_cp(cp_mesh=cp_mesh, cp_mamba_impl=self.cp_mamba_impl)
+                for _ in range(3)
+            ]
+        )
+        model_cp_hsdp = FSDP(
+            model_cp,
+            device_mesh=mesh,
+            auto_wrap_policy=ModuleWrapPolicy([Mamba2CP]),
+            sharding_strategy=ShardingStrategy.FULL_SHARD,
+            use_orig_params=True,
+            device_id=self.device,
+        )
+        # NOTE: for grads to match the non-FSDP case, some scaling need to be performed. Options:
+        # 1) Change FSDP._gradient_predivide_factor from the DP world size to 1.0
+        # 2) Scale up the loss by a factor of the DP world size
+        # The latter is also automatically handled if the loss function scales by the world size,
+        # as in the case of a mean or default cross_entropy loss with equals tokens per rank, but it
+        # also makes the outputs mismatch, while 1) keeps the FSDP and non-FSDP outputs the same.
+        #
+        # We just use the mean for the loss below.
+
+        # Different CP groups get different inputs
+
+        n_cp_groups = mesh["inter_node"].size()
+        inputs = self.get_inputs(requires_grad=True, batch_size=n_cp_groups)
+        inputs_copy = deepcopy(inputs)
+        inputs_cp_hsdp = self.get_cp_shard(
+            inputs_copy.tensor_split(n_cp_groups, dim=0)[cp_mesh.get_local_rank()],
+            n_shards=cp_mesh.size(),
+            rank=cp_mesh.get_local_rank(),
+        )
+
+        outputs = model(inputs)
+        outputs.mean().backward()
+        outputs_cp_fsdp = model_cp_hsdp(inputs_cp_hsdp)
+        outputs_cp_fsdp.mean().backward()
+
+        with FSDP.summon_full_params(model_cp_hsdp, with_grads=True):
+            dist.barrier()
+            _test_model_model_cp_grads_close(model, model_cp_hsdp, all_reduce=False)
+
+
+class TestHSDP1MHACPRing(_DTestModelBase):
+    """
+    Test HSDP + CP for MHACP where the HSDP and CP dims cover the same subgroups
+    """
+
+    cp_attn_impl = "ring"
+
+    @pytest.mark.world_size(4)
+    def test_fwd(self):
+        mesh = dist.device_mesh.init_device_mesh(
+            "cuda", (2, 2), mesh_dim_names=("inter_node", "intra_node")
+        )
+        cp_mesh = mesh["intra_node"]
+        model = nn.Sequential(*[self.get_mha() for _ in range(3)])
+        model_cp = nn.Sequential(
+            *[
+                self.get_mha_cp(cp_mesh=cp_mesh, cp_attn_impl=self.cp_attn_impl)
+                for _ in range(3)
+            ]
+        )
+        model_cp_hsdp = FSDP(
+            model_cp,
+            device_mesh=mesh,
+            auto_wrap_policy=ModuleWrapPolicy([Mamba2CP]),
+            sharding_strategy=ShardingStrategy.FULL_SHARD,
+            use_orig_params=True,
+            device_id=self.device,
+        )
+        # Different CP groups get different inputs
+        inputs = self.get_inputs(
+            seed=42 + mesh["inter_node"].get_local_rank(), dtype=torch.bfloat16
+        )
+        inputs_cp = self.get_cp_shard(
+            inputs, n_shards=cp_mesh.size(), rank=cp_mesh.get_local_rank()
+        )
+
+        outputs = model(inputs)
+        outputs_cp_hsdp = model_cp_hsdp(inputs_cp)
+
+        outputs_shard = self.get_cp_shard(
+            outputs, n_shards=cp_mesh.size(), rank=cp_mesh.get_local_rank()
+        )
+        tol = 1e-3
+        torch.testing.assert_close(outputs_cp_hsdp, outputs_shard, atol=tol, rtol=tol)
+
+    @pytest.mark.world_size(4)
+    def test_bwd(self):
+        mesh = dist.device_mesh.init_device_mesh(
+            "cuda", (2, 2), mesh_dim_names=("inter_node", "intra_node")
+        )
+        cp_mesh = mesh["intra_node"]
+        model = nn.Sequential(*[self.get_mha() for _ in range(3)])
+        model_cp = nn.Sequential(
+            *[
+                self.get_mha_cp(cp_mesh=cp_mesh, cp_attn_impl=self.cp_attn_impl)
+                for _ in range(3)
+            ]
+        )
+        model_cp_hsdp = FSDP(
+            model_cp,
+            device_mesh=mesh,
+            auto_wrap_policy=ModuleWrapPolicy([Mamba2CP]),
+            sharding_strategy=ShardingStrategy.FULL_SHARD,
+            use_orig_params=True,
+            device_id=self.device,
+        )
+        # NOTE: for grads to match the non-FSDP case, some scaling need to be performed. Options:
+        # 1) Change FSDP._gradient_predivide_factor from the DP world size to 1.0
+        # 2) Scale up the loss by a factor of the DP world size
+        # The latter is also automatically handled if the loss function scales by the world size,
+        # as in the case of a mean or default cross_entropy loss with equals tokens per rank, but it
+        # also makes the outputs mismatch, while 1) keeps the FSDP and non-FSDP outputs the same.
+        #
+        # We just use the mean for the loss below.
+
+        # Different CP groups get different inputs
+
+        n_cp_groups = mesh["inter_node"].size()
+        inputs = self.get_inputs(
+            requires_grad=True, batch_size=n_cp_groups, dtype=torch.bfloat16
+        )
+        inputs_copy = deepcopy(inputs)
+        inputs_cp_hsdp = self.get_cp_shard(
+            inputs_copy.tensor_split(n_cp_groups, dim=0)[cp_mesh.get_local_rank()],
+            n_shards=cp_mesh.size(),
+            rank=cp_mesh.get_local_rank(),
+        )
+
+        outputs = model(inputs)
+        outputs.mean().backward()
+        outputs_cp_fsdp = model_cp_hsdp(inputs_cp_hsdp)
+        outputs_cp_fsdp.mean().backward()
+
+        with FSDP.summon_full_params(model_cp_hsdp, with_grads=True):
+            dist.barrier()
+            _test_model_model_cp_grads_close(model, model_cp_hsdp, all_reduce=False)
+
+
+class TestHSDP1MHACPZigZag(_DTestModelBase):
+    """
+    Test HSDP + CP for MHACP where the HSDP and CP dims cover the same subgroups
+    """
+
+    cp_attn_impl = "zigzag"
+
+    @pytest.mark.world_size(4)
+    def test_fwd(self):
+        mesh = dist.device_mesh.init_device_mesh(
+            "cuda", (2, 2), mesh_dim_names=("inter_node", "intra_node")
+        )
+        cp_mesh = mesh["intra_node"]
+        model = nn.Sequential(*[self.get_mha() for _ in range(3)])
+        model_cp = nn.Sequential(
+            *[
+                self.get_mha_cp(cp_mesh=cp_mesh, cp_attn_impl=self.cp_attn_impl)
+                for _ in range(3)
+            ]
+        )
+        model_cp_hsdp = FSDP(
+            model_cp,
+            device_mesh=mesh,
+            auto_wrap_policy=ModuleWrapPolicy([Mamba2CP]),
+            sharding_strategy=ShardingStrategy.FULL_SHARD,
+            use_orig_params=True,
+            device_id=self.device,
+        )
+        # Different CP groups get different inputs
+        inputs = self.get_inputs(
+            seed=42 + mesh["inter_node"].get_local_rank(), dtype=torch.bfloat16
+        )
+        inputs_cp = self.get_cp_shard(
+            inputs, n_shards=cp_mesh.size(), rank=cp_mesh.get_local_rank()
+        )
+
+        outputs = model(inputs)
+        outputs_cp_hsdp = model_cp_hsdp(inputs_cp)
+
+        outputs_shard = self.get_cp_shard(
+            outputs, n_shards=cp_mesh.size(), rank=cp_mesh.get_local_rank()
+        )
+        tol = 1e-3
+        torch.testing.assert_close(outputs_cp_hsdp, outputs_shard, atol=tol, rtol=tol)
+
+    @pytest.mark.world_size(4)
+    def test_bwd(self):
+        mesh = dist.device_mesh.init_device_mesh(
+            "cuda", (2, 2), mesh_dim_names=("inter_node", "intra_node")
+        )
+        cp_mesh = mesh["intra_node"]
+        model = nn.Sequential(*[self.get_mha() for _ in range(3)])
+        model_cp = nn.Sequential(
+            *[
+                self.get_mha_cp(cp_mesh=cp_mesh, cp_attn_impl=self.cp_attn_impl)
+                for _ in range(3)
+            ]
+        )
+        model_cp_hsdp = FSDP(
+            model_cp,
+            device_mesh=mesh,
+            auto_wrap_policy=ModuleWrapPolicy([Mamba2CP]),
+            sharding_strategy=ShardingStrategy.FULL_SHARD,
+            use_orig_params=True,
+            device_id=self.device,
+        )
+        # NOTE: for grads to match the non-FSDP case, some scaling need to be performed. Options:
+        # 1) Change FSDP._gradient_predivide_factor from the DP world size to 1.0
+        # 2) Scale up the loss by a factor of the DP world size
+        # The latter is also automatically handled if the loss function scales by the world size,
+        # as in the case of a mean or default cross_entropy loss with equals tokens per rank, but it
+        # also makes the outputs mismatch, while 1) keeps the FSDP and non-FSDP outputs the same.
+        #
+        # We just use the mean for the loss below.
+
+        # Different CP groups get different inputs
+
+        n_cp_groups = mesh["inter_node"].size()
+        inputs = self.get_inputs(
+            requires_grad=True, batch_size=n_cp_groups, dtype=torch.bfloat16
+        )
+        inputs_copy = deepcopy(inputs)
+        inputs_cp_hsdp = self.get_cp_shard(
+            inputs_copy.tensor_split(n_cp_groups, dim=0)[cp_mesh.get_local_rank()],
+            n_shards=cp_mesh.size(),
+            rank=cp_mesh.get_local_rank(),
+        )
+
+        outputs = model(inputs)
+        outputs.mean().backward()
+        outputs_cp_fsdp = model_cp_hsdp(inputs_cp_hsdp)
+        outputs_cp_fsdp.mean().backward()
+
+        with FSDP.summon_full_params(model_cp_hsdp, with_grads=True):
+            dist.barrier()
+            _test_model_model_cp_grads_close(model, model_cp_hsdp, all_reduce=False)
+
+
+class TestModelSerialRing(_DTestModelBase):
+    cp_mamba_impl = "serial"
+    cp_attn_impl = "ring"
+
+    def test_fwd(self):
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        model = self.get_model()
+        model_cp = self.get_model_cp(
+            cp_mesh, cp_mamba_impl=self.cp_mamba_impl, cp_attn_impl=self.cp_attn_impl
+        )
+
+        inputs = self.get_input_toks()
+        inputs_cp = self.get_cp_shard(inputs)
+
+        outputs = model(inputs).logits
+        outputs_cp = model_cp(inputs_cp).logits
+
+        outputs_shard = self.get_cp_shard(outputs)
+        # Requires a higher tolerance.
+        tol = 1e-1
+        torch.testing.assert_close(outputs_cp, outputs_shard, atol=tol, rtol=tol)
+
+    def test_bwd(self):
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        model = self.get_model()
+        model_cp = self.get_model_cp(
+            cp_mesh, cp_mamba_impl=self.cp_mamba_impl, cp_attn_impl=self.cp_attn_impl
+        )
+
+        inputs = self.get_input_toks()
+        inputs_copy = deepcopy(inputs)
+        inputs_cp = self.get_cp_shard(inputs_copy)
+
+        outputs = model(inputs).logits
+        outputs.sum().backward()
+        outputs_cp = model_cp(inputs_cp).logits
+        outputs_cp.sum().backward()
+
+        # Parameter grads should match after all-reducing.
+        # Requires high tol
+        _test_model_model_cp_grads_close(model, model_cp)
+
+
+class TestModelAllGatherZigZag(_DTestModelBase):
+    cp_mamba_impl = "allgather"
+    cp_attn_impl = "zigzag"
+
+    def test_fwd(self):
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        model = self.get_model()
+        model_cp = self.get_model_cp(
+            cp_mesh, cp_mamba_impl=self.cp_mamba_impl, cp_attn_impl=self.cp_attn_impl
+        )
+
+        inputs = self.get_input_toks()
+        inputs_cp = self.get_cp_shard(inputs)
+
+        outputs = model(inputs).logits
+        outputs_cp = model_cp(inputs_cp).logits
+
+        outputs_shard = self.get_cp_shard(outputs)
+        # Requires a higher tolerance.
+        tol = 1e-1
+        torch.testing.assert_close(outputs_cp, outputs_shard, atol=tol, rtol=tol)
+
+    def test_bwd(self):
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        model = self.get_model()
+        model_cp = self.get_model_cp(
+            cp_mesh, cp_mamba_impl=self.cp_mamba_impl, cp_attn_impl=self.cp_attn_impl
+        )
+
+        inputs = self.get_input_toks()
+        inputs_copy = deepcopy(inputs)
+        inputs_cp = self.get_cp_shard(inputs_copy)
+
+        outputs = model(inputs).logits
+        outputs.sum().backward()
+        outputs_cp = model_cp(inputs_cp).logits
+        outputs_cp.sum().backward()
+
+        # Parameter grads should match after all-reducing.
+        # Requires high tol
+        _test_model_model_cp_grads_close(model, model_cp)
+
+
+class TestModelSerialZigZag(_DTestModelBase):
+    cp_mamba_impl = "serial"
+    cp_attn_impl = "zigzag"
+
+    def test_fwd(self):
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        model = self.get_model()
+        model_cp = self.get_model_cp(
+            cp_mesh, cp_mamba_impl=self.cp_mamba_impl, cp_attn_impl=self.cp_attn_impl
+        )
+
+        inputs = self.get_input_toks()
+        inputs_cp = self.get_cp_shard(inputs)
+
+        outputs = model(inputs).logits
+        outputs_cp = model_cp(inputs_cp).logits
+
+        outputs_shard = self.get_cp_shard(outputs)
+        # Requires a higher tolerance.
+        tol = 1e-1
+        torch.testing.assert_close(outputs_cp, outputs_shard, atol=tol, rtol=tol)
+
+    def test_bwd(self):
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        model = self.get_model()
+        model_cp = self.get_model_cp(
+            cp_mesh, cp_mamba_impl=self.cp_mamba_impl, cp_attn_impl=self.cp_attn_impl
+        )
+
+        inputs = self.get_input_toks()
+        inputs_copy = deepcopy(inputs)
+        inputs_cp = self.get_cp_shard(inputs_copy)
+
+        outputs = model(inputs).logits
+        outputs.sum().backward()
+        outputs_cp = model_cp(inputs_cp).logits
+        outputs_cp.sum().backward()
+
+        # Parameter grads should match after all-reducing.
+        # Requires high tol
+        _test_model_model_cp_grads_close(model, model_cp)
+
+
+class TestModelAllGatherRing(_DTestModelBase):
+    cp_mamba_impl = "allgather"
+    cp_attn_impl = "ring"
+
+    def test_fwd(self):
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        model = self.get_model()
+        model_cp = self.get_model_cp(
+            cp_mesh, cp_mamba_impl=self.cp_mamba_impl, cp_attn_impl=self.cp_attn_impl
+        )
+
+        inputs = self.get_input_toks()
+        inputs_cp = self.get_cp_shard(inputs)
+
+        outputs = model(inputs).logits
+        outputs_cp = model_cp(inputs_cp).logits
+
+        outputs_shard = self.get_cp_shard(outputs)
+        # Requires a higher tolerance.
+        tol = 1e-1
+        torch.testing.assert_close(outputs_cp, outputs_shard, atol=tol, rtol=tol)
+
+    def test_bwd(self):
+        cp_mesh = dist.device_mesh.init_device_mesh("cuda", (self.world_size,))
+        model = self.get_model()
+        model_cp = self.get_model_cp(
+            cp_mesh, cp_mamba_impl=self.cp_mamba_impl, cp_attn_impl=self.cp_attn_impl
+        )
+
+        inputs = self.get_input_toks()
+        inputs_copy = deepcopy(inputs)
+        inputs_cp = self.get_cp_shard(inputs_copy)
+
+        outputs = model(inputs).logits
+        outputs.sum().backward()
+        outputs_cp = model_cp(inputs_cp).logits
+        outputs_cp.sum().backward()
+
+        # Parameter grads should match after all-reducing.
+        # Requires high tol
+        _test_model_model_cp_grads_close(model, model_cp)

--- a/tests/mamba_cp/timing.py
+++ b/tests/mamba_cp/timing.py
@@ -1,0 +1,228 @@
+import argparse
+import datetime
+import functools
+import os
+from functools import partial
+from typing import Type
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    CheckpointImpl,
+    apply_activation_checkpointing,
+    checkpoint_wrapper,
+)
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import MixedPrecision, ShardingStrategy
+from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
+
+from mamba_ssm.models.config_mamba import MambaConfig
+from mamba_ssm.models.mixer_seq_simple import MambaLMHeadModel
+from mamba_ssm.modules.block import Block
+
+non_reentrant_wrapper = partial(
+    checkpoint_wrapper,
+    checkpoint_impl=CheckpointImpl.NO_REENTRANT,
+)
+
+
+def get_wrapper(block):
+    auto_wrap_policy = functools.partial(
+        transformer_auto_wrap_policy,
+        transformer_layer_cls={
+            block,
+        },
+    )
+
+    return auto_wrap_policy
+
+
+def get_mem_dict():
+    mem_dict = {}
+    for k, v in torch.cuda.memory_stats().items():
+        if all(s in k for s in (".all.", "bytes")) and any(
+            s in k for s in ("current", "peak")
+        ):
+            mem_dict[k.replace("bytes", "gib")] = v / 2**30
+
+    return mem_dict
+
+
+def apply_fsdp_checkpointing(model, block: Type[nn.Module] = Block, p=1):
+    """
+    Apply selective activation checkpointing.
+
+    Selectivity is defined as a percentage p, which means we apply ac
+    on p of the total blocks. p is a floating number in the range of
+    [0, 1].
+
+    Some examples:
+    p = 0: no ac for all blocks. same as `fsdp_activation_checkpointing=False`
+    p = 1: apply ac on every block. i.e. "full ac".
+    p = 1/2: [ac, no-ac, ac, no-ac, ...]
+    p = 1/3: [no-ac, ac, no-ac,   no-ac, ac, no-ac,   ...]
+    p = 2/3: [ac, no-ac, ac,    ac, no-ac, ac,    ...]
+    Since blocks are homogeneous, we make ac blocks evenly spaced among
+    all blocks.
+
+    Implementation:
+    For a given ac ratio p, we should essentially apply ac on every "1/p"
+    blocks. The first ac block can be as early as the 0th block, or as
+    late as the "1/p"th block, and we pick the middle one: (0.5p)th block.
+    Therefore, we are essentially to apply ac on:
+    (0.5/p)th block, (1.5/p)th block, (2.5/p)th block, etc., and of course,
+    with these values rounding to integers.
+    Since ac is applied recursively, we can simply use the following math
+    in the code to apply ac on corresponding blocks.
+    """
+    block_idx = 0
+    cut_off = 1 / 2
+    # when passing p as a fraction number (e.g. 1/3), it will be interpreted
+    # as a string in argv, thus we need eval("1/3") here for fractions.
+    p = eval(p) if isinstance(p, str) else p
+
+    def selective_checkpointing(submodule):
+        nonlocal block_idx
+        nonlocal cut_off
+
+        if isinstance(submodule, block):
+            block_idx += 1
+            if block_idx * p >= cut_off:
+                cut_off += 1
+                return True
+        return False
+
+    apply_activation_checkpointing(
+        model,
+        checkpoint_wrapper_fn=non_reentrant_wrapper,
+        check_fn=selective_checkpointing,
+    )
+
+
+bamba_9dot8b_defaults = {
+    "d_model": 4096,
+    "d_intermediate": 14336,
+    "n_layer": 32,
+    "vocab_size": 128256,
+    "ssm_cfg": {"layer": "Mamba2"},
+    "attn_layer_idx": [9, 18, 27],
+    "attn_cfg": {
+        "causal": True,
+        "d_conv": 0,
+        "head_dim": 128,
+        "num_heads": 32,
+        "num_heads_kv": 8,
+        "out_proj_bias": False,
+        "qkv_proj_bias": False,
+        "rotary_emb_dim": 64,
+    },
+    "rms_norm": True,
+    "residual_in_fp32": True,
+    "fused_add_norm": True,
+    "pad_vocab_size_multiple": 16,
+    "tie_embeddings": False,
+}
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cp", action="store_true")
+    parser.add_argument("--cp_mamba_impl", type=str, default="allgather")
+    parser.add_argument("--cp_attn_impl", type=str, default="zigzag")
+    parser.add_argument("--mamba_only", action="store_true")
+    parser.add_argument("--no_ac", action="store_true")
+    parser.add_argument("--warmups", type=int, default=2)
+    parser.add_argument("--iters", type=int, default=5)
+    parser.add_argument("--seq_len", type=int, default=4096)
+    parser.add_argument("--batch_size", type=int, default=1)
+    parser.add_argument("--n_layer", type=int, default=bamba_9dot8b_defaults["n_layer"])
+    args = parser.parse_args()
+
+    cli_args = {
+        "n_layer": args.n_layer,
+    }
+    if args.mamba_only:
+        cli_args["attn_layer_idx"] = []
+    config = MambaConfig(**{**bamba_9dot8b_defaults, **cli_args})
+
+    rank = int(os.environ["RANK"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+
+    if not rank:
+        print(f"{args=}")
+        print(f"{config=}")
+
+    dtype = torch.bfloat16
+    device = torch.device(f"cuda:{local_rank}")
+    torch.cuda.set_device(device)
+    dist.init_process_group(
+        backend="nccl", timeout=datetime.timedelta(seconds=60), device_id=device
+    )
+    mesh = dist.device_mesh.init_device_mesh("cuda", (world_size,))
+
+    model = MambaLMHeadModel(
+        config=config,
+        cp_mesh=mesh if args.cp else None,
+        cp_mamba_impl=args.cp_mamba_impl if args.cp else None,
+        cp_attn_impl=args.cp_attn_impl if args.cp else None,
+    )
+
+    model = FSDP(
+        model,
+        auto_wrap_policy=get_wrapper(Block),
+        sharding_strategy=ShardingStrategy.FULL_SHARD,
+        use_orig_params=True,
+        device_id=device,
+        mixed_precision=MixedPrecision(
+            param_dtype=dtype,
+            reduce_dtype=dtype,
+            buffer_dtype=dtype,
+        ),
+    )
+    if not args.no_ac:
+        apply_fsdp_checkpointing(model)
+    optim = torch.optim.AdamW(model.parameters(), lr=1e-7, foreach=False)
+
+    inputs = torch.randint(
+        config.vocab_size,
+        size=(args.batch_size, args.seq_len),
+        device=device,
+    )
+
+    def train_one_step():
+        outputs = model(inputs)
+        loss = F.cross_entropy(
+            outputs.logits.view(-1, outputs.logits.shape[-1]), inputs.view(-1)
+        )
+        loss.backward()
+        optim.step()
+        optim.zero_grad()
+
+    for _ in range(args.warmups):
+        train_one_step()
+
+    start = torch.cuda.Event(enable_timing=True)
+    stop = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(args.iters):
+        train_one_step()
+    dist.barrier()
+    stop.record()
+    torch.cuda.synchronize()
+    secs = start.elapsed_time(stop) / 1e3
+
+    total_toks = args.batch_size * args.seq_len * world_size * args.iters
+    toks_per_sec = total_toks / secs
+    toks_per_sec_per_gpu = toks_per_sec / world_size
+    if not rank:
+        print(f"Total tokens: {total_toks}")
+        print(f"Total Secs: {secs}")
+        print(f"Tok/sec {toks_per_sec}")
+        print(f"Tok/sec/gpu {toks_per_sec_per_gpu}")
+
+        print(f"{get_mem_dict()}")
+
+    dist.destroy_process_group()

--- a/tests/mamba_cp/timing.py
+++ b/tests/mamba_cp/timing.py
@@ -128,11 +128,11 @@ bamba_9dot8b_defaults = {
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--cp", type=bool, default=False)
+    parser.add_argument("--cp", action="store_true")
     parser.add_argument("--cp_mamba_impl", type=str, default="allgather")
     parser.add_argument("--cp_attn_impl", type=str, default="zigzag")
-    parser.add_argument("--mamba_only", type=bool, default=False)
-    parser.add_argument("--no_ac", type=bool, default=False)
+    parser.add_argument("--mamba_only", action="store_true")
+    parser.add_argument("--no_ac", action="store_true")
     parser.add_argument("--warmups", type=int, default=2)
     parser.add_argument("--iters", type=int, default=5)
     parser.add_argument("--seq_len", type=int, default=4096)

--- a/tests/mamba_cp/timing.py
+++ b/tests/mamba_cp/timing.py
@@ -128,11 +128,11 @@ bamba_9dot8b_defaults = {
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--cp", action="store_true")
+    parser.add_argument("--cp", type=bool, default=False)
     parser.add_argument("--cp_mamba_impl", type=str, default="allgather")
     parser.add_argument("--cp_attn_impl", type=str, default="zigzag")
-    parser.add_argument("--mamba_only", action="store_true")
-    parser.add_argument("--no_ac", action="store_true")
+    parser.add_argument("--mamba_only", type=bool, default=False)
+    parser.add_argument("--no_ac", type=bool, default=False)
     parser.add_argument("--warmups", type=int, default=2)
     parser.add_argument("--iters", type=int, default=5)
     parser.add_argument("--seq_len", type=int, default=4096)

--- a/tests/mamba_cp/timing_e2e.py
+++ b/tests/mamba_cp/timing_e2e.py
@@ -128,7 +128,7 @@ bamba_9dot8b_defaults = {
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--cp", action="store_true")
+    parser.add_argument("--no_cp", action="store_true")
     parser.add_argument("--cp_degree", type=int, default=torch.cuda.device_count())
     parser.add_argument("--cp_mamba_impl", type=str, default="allgather")
     parser.add_argument("--cp_attn_impl", type=str, default="zigzag")
@@ -175,10 +175,10 @@ if __name__ == "__main__":
 
     model = MambaLMHeadModel(
         config=config,
-        cp_mesh=cp_mesh if args.cp else None,
-        cp_mamba_impl=args.cp_mamba_impl if args.cp else None,
-        cp_mamba_recompute=args.cp_mamba_recompute if args.cp else None,
-        cp_attn_impl=args.cp_attn_impl if args.cp else None,
+        cp_mesh=cp_mesh if not args.no_cp else None,
+        cp_mamba_impl=args.cp_mamba_impl if not args.no_cp else None,
+        cp_mamba_recompute=args.cp_mamba_recompute if not args.no_cp else None,
+        cp_attn_impl=args.cp_attn_impl if not args.no_cp else None,
     )
 
     model = FSDP(

--- a/tests/mamba_cp/timing_mamba_layers.py
+++ b/tests/mamba_cp/timing_mamba_layers.py
@@ -1,27 +1,29 @@
 import argparse
 import datetime
 import os
+from contextlib import nullcontext
 
 import torch
 import torch.distributed as dist
 import torch.nn as nn
 
 from mamba_ssm.modules.mamba2_cp import Mamba2CP
-from contextlib import nullcontext
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--cp_mamba_impl", type=str, default="allgather")
+    parser.add_argument("--cp_mamba_recompute", action="store_true")
     parser.add_argument("--d_model", type=int, default=4096)  # bamba 9.8b default
     parser.add_argument("--iters", type=int, default=20)
     parser.add_argument("--n_layers", type=int, default=1)
     parser.add_argument("--project", type=str, default=None)
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--seq_len_per_gpu", type=int, default=65536)
-    parser.add_argument("--wandb", type=bool, default=False)
-    parser.add_argument("--bwd", type=bool, default=False)
+    parser.add_argument("--wandb", action="store_true")
+    parser.add_argument("--no_bwd", action="store_true")
     parser.add_argument("--warmups", type=int, default=3)
+    parser.add_argument("--no_barrier_after_iter", action="store_true", default=False)
     args = parser.parse_args()
 
     rank = int(os.environ["RANK"])
@@ -46,6 +48,7 @@ if __name__ == "__main__":
                     d_model=args.d_model,
                     cp_mesh=mesh,
                     cp_mamba_impl=args.cp_mamba_impl,
+                    cp_mamba_recompute=args.cp_mamba_recompute,
                     device=device,
                     dtype=dtype,
                 )
@@ -64,10 +67,14 @@ if __name__ == "__main__":
         # Initial barrier to avoid possible issues w/ P2P comms being the first ops.
         # https://docs.pytorch.org/docs/stable/distributed.html#torch.distributed.batch_isend_irecv
         dist.barrier()
-        ctx = nullcontext if args.bwd else torch.no_grad
+        ctx = torch.no_grad if args.no_bwd else nullcontext
         with ctx():
             for _ in range(args.warmups):
-                mamba_stack(inputs)
+                outputs = mamba_stack(inputs)
+                if not args.no_bwd:
+                    outputs.sum().backward()
+                    mamba_stack.zero_grad()
+                del outputs
         dist.barrier()
 
         start = torch.cuda.Event(enable_timing=True)
@@ -76,13 +83,15 @@ if __name__ == "__main__":
         with ctx():
             for _ in range(args.iters):
                 outputs = mamba_stack(inputs)
-                if args.bwd:
+                if not args.no_bwd:
                     outputs.sum().backward()
                     mamba_stack.zero_grad()
+                del outputs
                 # Barrier after each iteration to sync processes. Otherwise, we would amortize the
                 # serial impl bubble over all iters, e.g. Mimics actual sync points expected in full
                 # e2e code
-                dist.barrier()
+                if not args.no_barrier_after_iter:
+                    dist.barrier()
         stop.record()
         torch.cuda.synchronize()
 
@@ -93,10 +102,21 @@ if __name__ == "__main__":
         toks_per_sec = total_toks / secs
         toks_per_sec_per_gpu = toks_per_sec / world_size
         if not rank:
+            reserved_mem = (
+                torch.cuda.max_memory_reserved(device=torch.cuda.current_device())
+                / 2**30
+            )
+            allocated_mem = (
+                torch.cuda.max_memory_allocated(device=torch.cuda.current_device())
+                / 2**30
+            )
+
             print(f"Total tokens: {total_toks}")
             print(f"Total Secs: {secs}")
             print(f"Tok/sec {toks_per_sec}")
             print(f"Tok/sec/gpu {toks_per_sec_per_gpu}")
+            print(f"Reserved GiB {reserved_mem}")
+            print(f"Allocated GiB {allocated_mem}")
 
             if args.wandb:
                 import wandb
@@ -108,6 +128,8 @@ if __name__ == "__main__":
                     {
                         "tok_sec_gpu": toks_per_sec_per_gpu,
                         "sec": secs,
+                        "reserved GiB": reserved_mem,
+                        "allocated GiB": allocated_mem,
                     },
                     step=1,
                 )

--- a/tests/mamba_cp/timing_single_mamba_layer_fwd.py
+++ b/tests/mamba_cp/timing_single_mamba_layer_fwd.py
@@ -1,0 +1,95 @@
+import argparse
+import datetime
+import os
+
+import torch
+import torch.distributed as dist
+
+from mamba_ssm.modules.mamba2_cp import Mamba2CP
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cp_mamba_impl", type=str, default="allgather")
+    parser.add_argument("--d_model", type=int, default=4096)  # bamba 9.8b default
+    parser.add_argument("--warmups", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=50)
+    parser.add_argument("--seq_len_per_gpu", type=int, default=8192)
+    parser.add_argument("--batch_size", type=int, default=1)
+    parser.add_argument("--wandb", action="store_true")
+    parser.add_argument("--project", type=str, default=None)
+    parser.add_argument("--run_id", type=str, default=None)
+    args = parser.parse_args()
+
+    rank = int(os.environ["RANK"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+
+    if not rank:
+        print(f"{args=}")
+
+    dtype = torch.bfloat16
+    device = torch.device(f"cuda:{local_rank}")
+    torch.cuda.set_device(device)
+    try:
+        dist.init_process_group(
+            backend="nccl", timeout=datetime.timedelta(seconds=60), device_id=device
+        )
+        mesh = dist.device_mesh.init_device_mesh("cuda", (world_size,))
+
+        mamba = Mamba2CP(
+            d_model=args.d_model,
+            cp_mesh=mesh,
+            cp_mamba_impl=args.cp_mamba_impl,
+            device=device,
+            dtype=dtype,
+        )
+
+        inputs = torch.randn(
+            args.batch_size,
+            args.seq_len_per_gpu,
+            args.d_model,
+            device=device,
+            dtype=dtype,
+        )
+
+        with torch.no_grad():
+            for _ in range(args.warmups):
+                mamba(inputs)
+
+        start = torch.cuda.Event(enable_timing=True)
+        stop = torch.cuda.Event(enable_timing=True)
+        start.record()
+        with torch.no_grad():
+            for _ in range(args.iters):
+                mamba(inputs)
+        dist.barrier()
+        stop.record()
+        torch.cuda.synchronize()
+        secs = start.elapsed_time(stop) / 1e3
+
+        toks_per_gpu = args.batch_size * args.seq_len_per_gpu * args.iters
+        total_toks = toks_per_gpu * world_size
+        toks_per_sec = total_toks / secs
+        toks_per_sec_per_gpu = toks_per_sec / world_size
+        if not rank:
+            print(f"Total tokens: {total_toks}")
+            print(f"Total Secs: {secs}")
+            print(f"Tok/sec {toks_per_sec}")
+            print(f"Tok/sec/gpu {toks_per_sec_per_gpu}")
+
+            if args.wandb:
+                import wandb
+
+                config = vars(args)
+                config["seq_len"] = args.seq_len_per_gpu * world_size
+                wandb.init(project=args.project, id=args.run_id, config=config)
+                wandb.log(
+                    {
+                        "tok_sec_gpu": toks_per_sec_per_gpu,
+                        "sec": secs,
+                    },
+                    step=1,
+                )
+
+    finally:
+        dist.destroy_process_group()

--- a/tests/mamba_cp/timing_single_mamba_layer_fwd.py
+++ b/tests/mamba_cp/timing_single_mamba_layer_fwd.py
@@ -1,0 +1,102 @@
+import argparse
+import datetime
+import os
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from mamba_ssm.modules.mamba2_cp import Mamba2CP
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch_size", type=int, default=1)
+    parser.add_argument("--cp_mamba_impl", type=str, default="allgather")
+    parser.add_argument("--d_model", type=int, default=4096)  # bamba 9.8b default
+    parser.add_argument("--iters", type=int, default=50)
+    parser.add_argument("--n_layers", type=int, default=10)
+    parser.add_argument("--project", type=str, default=None)
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--seq_len_per_gpu", type=int, default=8192)
+    parser.add_argument("--wandb", action="store_true")
+    parser.add_argument("--warmups", type=int, default=10)
+    args = parser.parse_args()
+
+    rank = int(os.environ["RANK"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+
+    if not rank:
+        print(f"{args=}")
+
+    dtype = torch.bfloat16
+    device = torch.device(f"cuda:{local_rank}")
+    torch.cuda.set_device(device)
+    try:
+        dist.init_process_group(
+            backend="nccl", timeout=datetime.timedelta(seconds=60), device_id=device
+        )
+        mesh = dist.device_mesh.init_device_mesh("cuda", (world_size,))
+
+        mamba_stack = nn.Sequential(
+            *[
+                Mamba2CP(
+                    d_model=args.d_model,
+                    cp_mesh=mesh,
+                    cp_mamba_impl=args.cp_mamba_impl,
+                    device=device,
+                    dtype=dtype,
+                )
+                for _ in range(args.n_layers)
+            ]
+        )
+
+        inputs = torch.randn(
+            args.batch_size,
+            args.seq_len_per_gpu,
+            args.d_model,
+            device=device,
+            dtype=dtype,
+        )
+
+        with torch.no_grad():
+            for _ in range(args.warmups):
+                mamba_stack(inputs)
+
+        start = torch.cuda.Event(enable_timing=True)
+        stop = torch.cuda.Event(enable_timing=True)
+        start.record()
+        with torch.no_grad():
+            for _ in range(args.iters):
+                mamba_stack(inputs)
+        dist.barrier()
+        stop.record()
+        torch.cuda.synchronize()
+        secs = start.elapsed_time(stop) / 1e3
+
+        toks_per_gpu = args.batch_size * args.seq_len_per_gpu * args.iters
+        total_toks = toks_per_gpu * world_size
+        toks_per_sec = total_toks / secs
+        toks_per_sec_per_gpu = toks_per_sec / world_size
+        if not rank:
+            print(f"Total tokens: {total_toks}")
+            print(f"Total Secs: {secs}")
+            print(f"Tok/sec {toks_per_sec}")
+            print(f"Tok/sec/gpu {toks_per_sec_per_gpu}")
+
+            if args.wandb:
+                import wandb
+
+                config = vars(args)
+                config["seq_len"] = args.seq_len_per_gpu * world_size
+                wandb.init(project=args.project, id=args.run_id, config=config)
+                wandb.log(
+                    {
+                        "tok_sec_gpu": toks_per_sec_per_gpu,
+                        "sec": secs,
+                    },
+                    step=1,
+                )
+
+    finally:
+        dist.destroy_process_group()

--- a/usage.md
+++ b/usage.md
@@ -1,0 +1,41 @@
+# Mamba adoption
+
+We've been very happy to see Mamba being adopted by many organizations
+and research labs to speed up their training / inference.
+This page contains a partial list of places where Mamba is being used.
+If you'd like to add links to your organization / product / codebase, please open a
+PR or email us. We'd very much like to hear from you!
+
+## Large language models and multi-modal models
+
+- [Tencent's Hunyuan-TurboS (560B)](https://arxiv.org/abs/2505.15431)
+
+- [Nvidia Nemotron-H (8B, 47B, 56B)](https://research.nvidia.com/labs/adlr/nemotronh/)
+
+- [AI21 Jamba (398B)](https://www.ai21.com/blog/announcing-jamba-model-family/)
+
+- [IBM Bamba (9B)](https://research.ibm.com/blog/bamba-ssm-transformer-model)
+
+- [Mistral's Codestral (7B)](https://mistral.ai/news/codestral-mamba)
+
+- [Nvidia Mamba-2 Hybrid (8B)](https://arxiv.org/abs/2406.07887)
+
+- [Microsoft Samba (4B)](https://arxiv.org/abs/2406.07522v1)
+
+- [TII Falcon-Mamba (7B)](https://falconllm.tii.ae/tii-releases-first-sslm-with-falcon-mamba-7b.html)
+
+## Inference frameworks
+
+- vLLM
+
+- Nvidia's TensorRT-LLM
+
+## Hardware
+
+- Nvidia GPUs
+
+- [AMD GPUs](https://rocm.blogs.amd.com/artificial-intelligence/mamba/README.html)
+
+- [AWS Trainium 2](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/nki/tutorials/fused_mamba.html)
+
+

--- a/usage.md
+++ b/usage.md
@@ -14,6 +14,8 @@ PR or email us. We'd very much like to hear from you!
 
 - [AI21 Jamba (398B)](https://www.ai21.com/blog/announcing-jamba-model-family/)
 
+- [TII Falcon-H1 (34B)](https://falconllm.tii.ae/falcon-h1.html)
+
 - [IBM Bamba (9B)](https://research.ibm.com/blog/bamba-ssm-transformer-model)
 
 - [Mistral's Codestral (7B)](https://mistral.ai/news/codestral-mamba)


### PR DESCRIPTION
Context Parallel implementations of Mamba

Prelim perf nums:
* 128k ctx: in-node CP + in-node HSDP, ~2300 tok/sec for {1,2,4} nodes
* 256k ctx: world CP + in-node HSDP, ~1100 tok/sec on 2 nodes
* 512k ctx: world CP + in-node HSDP, ~700 tok/sec on 4 nodes

<img width="1352" alt="Scherm­afbeelding 2025-02-28 om 4 56 00 PM" src="https://github.com/user-attachments/assets/bb08a33f-394f-40c5-a5cf-7dbd72029388" />

Custom mamba CP impl + zigzag `ring-flash-attn`.
